### PR TITLE
MCP/CLI server, client layer, and demos

### DIFF
--- a/bin/config.nims
+++ b/bin/config.nims
@@ -1,1 +1,26 @@
 patch_file "nph", "phrenderer", "patches/phrenderer"
+
+--threadAnalysis:
+  off
+--define:
+  vm_exec_hooks
+--define:
+  nim_preview_hash_ref
+--define:
+  nim_type_names
+--define:
+  "chronicles_enabled=on"
+--define:
+  "chronicles_log_level=INFO"
+--define:
+  "chronicles_line_numbers"
+--define:
+  "chronicles_sinks=textlines[nocolors,file(/tmp/enu_cli.log,truncate)]"
+--define:
+  "ed_partial_subscriber"
+--define:
+  "no_godot"
+--path:
+  "../generated"
+--path:
+  "../src"

--- a/bin/demos/demo.nim
+++ b/bin/demos/demo.nim
@@ -1,0 +1,7 @@
+import client, models/[builds, colors]
+
+Enu.client.connect
+let build = Build.init(0, 0, -150)
+Enu.units.add build
+for i in 0 .. 10:
+  build.draw vec3(0, i, 0), (COMPUTED, col"000000")

--- a/bin/demos/demo_large.nim
+++ b/bin/demos/demo_large.nim
@@ -1,0 +1,23 @@
+import std/[os, math]
+import client
+import core, models/[bots, builds, units, colors]
+
+Enu.client.connect
+discard Enu.client.tick_until(3.seconds, Enu.client.connected)
+
+let build = Build.init(-20, 0, 20)
+build.voxels.immediate = true
+Enu.units.add build
+Enu.client.tick
+
+let palette = [col"fc0e0b", col"14f707", col"0067ff", col"d9eed8"]
+echo "drawing large mathy sine surface (40x40)..."
+for x in 0 ..< 40:
+  for z in 0 ..< 40:
+    let h = (sin(x.float / 5.0) + cos(z.float / 5.0)) * 4.0
+    let y = int(round(h)) + 8
+    build.draw(vec3(x.float, y.float, z.float), (MANUAL, palette[(x + z) mod 4]))
+  Enu.client.tick
+echo "BUILD=" & build.id
+Enu.client.every(1.second):
+  discard

--- a/bin/demos/demo_mcp.nim
+++ b/bin/demos/demo_mcp.nim
@@ -1,0 +1,51 @@
+import pkg/nimcp
+import client, models/[bots, colors]
+
+const CLAUDE_ORANGE = col"d97757"
+Enu.client.connect
+let bot = Bot.init(0, 0, -150, color = CLAUDE_ORANGE)
+
+Enu.units.add bot
+
+proc reply(q: UnitQuery): string =
+  ## A query's answer, flagging a genuine query failure (q.error) as a tool
+  ## error. eval bypasses this on purpose — its errors come back as plain
+  ## strings for the agent to interpret.
+  if q.error != "":
+    mark_tool_error()
+  answer q
+
+let server = mcp_server("enu-mini", "1.0.0"):
+  mcp_tool:
+    proc eval(code: string): string =
+      ## Evaluates Enu VM code in the player context.
+      bot.eval(code)
+
+  mcp_tool:
+    proc move(x, y, z: float): string =
+      ## Move your bot to (x, y, z).
+      let start = bot.position
+      let diff = vec3(x, y, z) - start
+      Enu.client.animate(1.second):
+        bot.position = start + diff * t
+      "moved"
+
+  mcp_tool:
+    proc rotate(degrees: float): string =
+      ## Rotate your bot to `degrees` of yaw.
+      let start = bot.rotation
+      let diff = degrees - start
+      Enu.client.animate(1.second):
+        bot.rotation = start + diff * t
+      "rotated"
+
+  mcp_tool:
+    proc screenshot(): string =
+      ## Take a screenshot from your bot's POV. Returns the PNG path.
+      reply bot.ask(UnitQuery(kind: SCREENSHOT))
+
+new_stdio_transport().serve(
+  server,
+  idle = proc() =
+    Enu.client.tick,
+)

--- a/bin/demos/demo_nautilus.nim
+++ b/bin/demos/demo_nautilus.nim
@@ -1,0 +1,45 @@
+import std/math
+import client
+import core, models/[builds, units, colors]
+
+Enu.client.connect
+
+const
+  turns = 7.0
+  a = 1.4
+  b = 0.10
+  tube_ratio = 0.22
+  line_density = 0
+  block_kind = MANUAL
+let
+  body_color = col"000000"
+  line_colors = [col"fc0e0b", col"0067ff", col"14f707", col"d9eed8"]
+
+let build = Build.init(0, 0, -150, save = true)
+Enu.units.add build
+
+var theta = 0.0
+build.buffer:
+  while theta < turns * 2 * PI:
+    let r = a * exp(b * theta)
+    let tube = r * tube_ratio
+    let cx = r * cos(theta)
+    let cz = r * sin(theta)
+    let rim = max(10, int(tube * 7))
+    for i in 0 ..< rim:
+      let phi = i.float / rim.float * 2 * PI
+      let px = cx + tube * cos(phi) * cos(theta)
+      let py = tube * (1.0 + sin(phi))
+      let pz = cz + tube * cos(phi) * sin(theta)
+      let num_lines = 1 shl clamp(line_density + int(log2(max(1.0, tube))), 0, 6)
+      let slot = (i * num_lines) div rim
+      let is_line = i == 0 or slot != ((i - 1) * num_lines) div rim
+      let color =
+        if is_line:
+          line_colors[
+            int(slot.float / num_lines.float * 16.0) mod line_colors.len
+          ]
+        else:
+          body_color
+      build.draw(vec3(px.round, py.round, pz.round), (block_kind, color))
+    theta += 0.7 / r

--- a/bin/demos/demo_query.nim
+++ b/bin/demos/demo_query.nim
@@ -1,0 +1,9 @@
+## Instance a bot, run one query against Enu's VM, print the answer.
+import client, models/bots
+
+Enu.client.connect
+
+let bot = Bot.init(0, 0, -150)
+Enu.units.add bot
+
+echo "1 + 1 = ", bot.eval("1 + 1")

--- a/bin/enu.nim
+++ b/bin/enu.nim
@@ -1,0 +1,317 @@
+import std/[os, strutils, math]
+import pkg/nimcp
+import client
+import core, models/[bots, units, colors]
+
+const
+  MOVE_SPEED = 50.0
+  ANGULAR_SPEED = 180.0
+  TELEPORT_DIST = 500.0
+
+let
+  cli_args = command_line_params()
+  server_mode = cli_args.len > 0 and cli_args[0] == "mcp"
+  ctx_id = "enu_mcp-" & generate_id()
+
+proc slug(s: string): string =
+  for c in s:
+    result.add(if c.is_alpha_numeric or c in {'-', '_'}: c else: '-')
+  if result.len > 24:
+    result.set_len(24)
+
+proc bot_id(agent_id: string): string =
+  result = "mcp_bot-" & ctx_id
+  if agent_id != "":
+    result &= "-" & agent_id.slug
+
+proc last_transform(id: string): Transform =
+  result = Transform.init(vec3(0, 0, 0))
+  if not Enu.client.prev.is_nil and "root_units" in Enu.client.prev:
+    for unit in EdSeq[Unit](Enu.client.prev["root_units"]):
+      if unit.id == id and ?unit.transform_value:
+        return unit.transform
+
+proc bot_for(agent_id = ""): Bot =
+  Enu.units.get_or_init(Bot, bot_id(agent_id)):
+    let pos = last_transform(bot_id(agent_id)).origin
+    let bot = Bot.init(pos.x, pos.y, pos.z, id = bot_id(agent_id))
+    bot.color = col(bot.id.hash)
+    bot.global_flags += VOXEL_VIEWER
+    if not server_mode:
+      bot.global_flags -= VISIBLE
+    bot
+
+proc glide(unit: Unit, target: Vector3, rotation = 0.0, instant = false) =
+  if instant or unit.transform.origin.distance_to(target) >= TELEPORT_DIST:
+    unit.move_to(target, rotation)
+  else:
+    Enu.client.every(33.milliseconds):
+      if unit.step_toward(target, rotation, MOVE_SPEED / 30, ANGULAR_SPEED / 30):
+        break
+  Enu.client.tick
+
+proc run(q: UnitQuery, agent_id = "", flag_errors = true): string =
+  Enu.client.online:
+    let answered =
+      try:
+        bot_for(agent_id).ask(q)
+      except SessionLost:
+        bot_for(agent_id).ask(q)
+    # A genuine query failure (transport, timeout, VM fault) arrives in
+    # `error` — surface it as a tool error. `eval` opts out (flag_errors =
+    # false): its results, errors and all, are returned verbatim for the agent.
+    if flag_errors and answered.error != "":
+      mark_tool_error()
+    answer answered
+
+proc eval_query(code: string, top_level = false, unit_id = ""): UnitQuery =
+  UnitQuery(kind: EVAL, code: code, top_level: top_level, unit_id: unit_id)
+
+let enu_server = mcp_server("enu", "1.0.0"):
+  mcp_tool:
+    proc screenshot(agent_id: string = ""): string =
+      ## Screenshot from your bot's view. Returns the saved PNG's path.
+      run UnitQuery(kind: SCREENSHOT), agent_id
+
+  mcp_tool:
+    proc screenshot_from_player(with_ui: bool = false): string =
+      ## Screenshot from the player's camera. Returns the saved PNG's path.
+      ## - with_ui: include the UI overlay (default false = just the world).
+      run UnitQuery(
+        kind: SCREENSHOT,
+        screenshot_from_player: not with_ui,
+        screenshot_with_ui: with_ui,
+      )
+
+  mcp_tool:
+    proc get_console(): string =
+      ## Get the current Enu console output.
+      run UnitQuery(kind: CONSOLE)
+
+  mcp_tool:
+    proc clear_console(): string =
+      ## Empty the Enu console.
+      run UnitQuery(kind: CLEAR_CONSOLE)
+
+  mcp_tool:
+    proc wait_for_script(unit_id: string, timeout: float = 30.0): string =
+      ## Reload `unit_id`'s script if it changed, then wait (up to `timeout`s)
+      ## for it to finish running and rendering. Returns the unit's world
+      ## bounds, or its error. Animated builds never finish — pass a short
+      ## timeout and expect "still running" (alive, not stuck).
+      Enu.client.online:
+        let deadline = get_mono_time() + timeout.seconds
+
+        let r = bot_for().ask(UnitQuery(kind: PING))
+        if r.error != "":
+          mark_tool_error()
+          return r.error
+        let unit = Enu.find_unit(unit_id)
+        if unit.is_nil:
+          mark_tool_error()
+          return "Error: unit not found: " & unit_id
+        if not Enu.client.tick_until(
+          timeout.seconds, SCRIPT_RUNNING notin unit.global_flags
+        ):
+          mark_tool_error()
+          return "Error: " & unit_id & " still running after " & $timeout & "s"
+        for error in unit.errors:
+          mark_tool_error()
+          return
+            "Error: " & error.msg &
+            (if error.location != "": " at " & error.location
+            else: "")
+
+        var settled_streak = 0
+        var last_pending = ""
+        while settled_streak < 3:
+          let p = bot_for().ask(
+              eval_query \"""
+              let u = find_by_id({unit_id.escape})
+              if u.is_nil:
+                "0"
+              else:
+                $u.pending_block_updates
+            """.dedent.strip
+            )
+          if p.error != "":
+            break
+          last_pending = p.result.strip
+          if last_pending == "0":
+            inc settled_streak
+          else:
+            settled_streak = 0
+          if settled_streak < 3:
+            if get_mono_time() > deadline:
+              mark_tool_error()
+              return
+                "Error: " & unit_id & " still rendering after " & $timeout &
+                "s (" & last_pending & " block updates pending)"
+            discard Enu.client.tick_until(init_duration(milliseconds = 100), false)
+        let b = bot_for().ask(
+            eval_query \"""
+          let u = find_by_id({unit_id.escape})
+          if u.is_nil:
+            ""
+          else:
+            var b = u.bounds
+            "bounds: " & $b.min & " .. " & $b.max
+        """.dedent.strip
+          )
+        if b.error == "": b.result else: ""
+
+  mcp_tool:
+    proc eval(
+        code: string, top_level: bool = false, unit_id: string = ""
+    ): string =
+      ## Evaluate Nim code in Enu's VM; returns the value, or "Error: ...".
+      ## - top_level: run as module-level code (imports, top-level defs);
+      ##   returns nothing. Default false runs in a block with a return value.
+      ## - unit_id: run in that unit's script context. Default = the player.
+      run(eval_query(code, top_level, unit_id), flag_errors = false)
+
+  mcp_tool:
+    proc get_level_dir(): string =
+      ## Get the directory path of the currently loaded level.
+      run UnitQuery(kind: LEVEL_DIR)
+
+  mcp_tool:
+    proc get_block_log(): string =
+      ## Blocks the player recently placed or erased by hand, oldest first —
+      ## the human's way to point the agent at spots ("delete what I marked
+      ## red"). One entry per line; cleared on save_and_reload.
+      run eval_query("block_log(active_unit())")
+
+  mcp_tool:
+    proc clear_block_log(): string =
+      ## Empty the block log so subsequent placements start a fresh
+      ## annotation session.
+
+      run eval_query \"""
+        clear_block_log(active_unit())
+        "cleared"
+      """.dedent.strip
+
+  mcp_tool:
+    proc units_near(x, y, z: float, radius: float = 30.0): string =
+      ## Units within `radius` of (x, y, z), nearest first, one per line.
+      run eval_query(\"units_near({x}, {y}, {z}, {radius})")
+
+  mcp_tool:
+    proc screenshot_top_down(
+        x: float, z: float, size: float = 30.0, agent_id: string = ""
+    ): string =
+      ## Orthographic top-down screenshot centered on (x, z). `size` is the
+      ## half-extent shown, in voxels (default 30 → a 60×60 area). Returns
+      ## the saved PNG's path.
+      Enu.client.online:
+        bot_for(agent_id).glide(vec3(x, 1.0, z), instant = not server_mode)
+      run UnitQuery(
+        kind: SCREENSHOT, screenshot_top_down: true, screenshot_size: size
+      ), agent_id
+
+  mcp_tool:
+    proc screenshot_at(
+        x, y, z: float,
+        distance: float = 30.0,
+        height: float = 8.0,
+        angle: float = 0.0,
+        agent_id: string = "",
+    ): string =
+      ## Framed screenshot of (x, y, z): the bot moves `distance` back,
+      ## `height` up, and `angle`° around it (0 = south, 90 = east,
+      ## 180 = north) then looks at it. Returns the saved PNG's path.
+      Enu.client.online:
+        let
+          target = vec3(x, y, z)
+          bot = bot_for(agent_id)
+          pose = frame(target, distance, height, angle)
+        bot.glide(pose.pos, pose.yaw_deg, instant = not server_mode)
+        bot.look_at(target)
+      run UnitQuery(kind: SCREENSHOT), agent_id
+
+  mcp_tool:
+    proc move_unit(id: string, x, y, z: float): string =
+      ## Move a unit to (x, y, z) and persist it (survives reload), unlike
+      ## set_position which only moves the live unit.
+      run eval_query \"""
+        let u = find_by_id({id.escape})
+        if u.is_nil:
+          "Error: unit not found: " & {id.escape}
+        else:
+          u.start_position = vec3({x}, {y}, {z})
+          u.position = vec3({x}, {y}, {z})
+          "moved " & u.id
+      """.dedent.strip
+
+  mcp_tool:
+    proc delete_unit(id: string): string =
+      ## Delete a unit and its on-disk script/data. Cannot be undone —
+      ## prefer move_unit if it might just be misplaced.
+      run eval_query \"""
+        let u = find_by_id({id.escape})
+        if u.is_nil:
+          "Error: unit not found: " & {id.escape}
+        else:
+          u.delete()
+          "deleted " & {id.escape}
+      """.dedent.strip
+
+  mcp_tool:
+    proc set_position(
+        x, y, z: float,
+        rotation: float = 0.0,
+        id: string = "",
+        agent_id: string = "",
+    ): string =
+      ## Glide a unit to (x, y, z) (teleports if over 500 units away).
+      ## - rotation: Y-axis rotation in degrees.
+      ## - id: unit to move (default: your bot; pass the player's id to move it).
+      Enu.client.online:
+        let unit =
+          if id == "":
+            Unit(bot_for(agent_id))
+          else:
+            Enu.find_unit(id)
+        if unit.is_nil:
+          mark_tool_error()
+          return "Error: Unit not found: " & id
+        unit.glide(vec3(x, y, z), rotation, instant = not server_mode)
+        ""
+
+proc remove_bots() =
+  if Enu.client.connected:
+    for unit in Enu.units.value:
+      if unit.id.starts_with("mcp_bot-" & ctx_id):
+        Enu.units -= unit
+    Enu.client.flush
+
+if server_mode:
+  Enu.client(id = ctx_id).connect
+  info "enu mcp started", pid = get_current_process_id(), address = Enu.client.address
+  new_stdio_transport().serve(
+    enu_server,
+    idle = proc() =
+      Enu.client.tick,
+  )
+elif cli_args.len == 0 or cli_args[0] in ["help", "--help", "-h"]:
+  echo "enu — drive a running Enu from the command line.\n"
+  echo enu_server.help_text("enu")
+  echo "\nRun as an MCP server with: enu mcp"
+else:
+  proc connect_to_enu(): bool {.gcsafe.} =
+    Enu.client(id = ctx_id).connect
+    result = Enu.client.tick_until(3.seconds, Enu.client.connected)
+    if not result:
+      stderr.write_line "Error: can't reach Enu at " & Enu.client.address &
+        " (is Enu running?)"
+
+  let exit_code = enu_server.dispatch_cli(
+    cli_args,
+    "enu",
+    failure = proc(text: string): bool {.gcsafe.} =
+      text.starts_with("Error"),
+    setup = connect_to_enu,
+  )
+  remove_bots()
+  quit exit_code

--- a/src/client.nim
+++ b/src/client.nim
@@ -1,0 +1,65 @@
+## Client-side convenience layer for native apps that drive a running Enu
+## over `ed` (the demos under `bin/`, the MCP server). `Enu` is a marker type
+## whose "class methods" wrap the boilerplate of standing up an `EdClient` and
+## reaching into its context, so an app reads `Enu.client` / `Enu.units`
+## instead of spelling out the context plumbing.
+##
+## This is purely an app-facing helper — regular Enu doesn't use it.
+
+import std/os
+import pkg/ed
+import core, models/units
+
+export ed, core, units
+
+type Enu* = object ## Marker type for the `Enu.*` helpers; never instantiated.
+
+var enu_client {.threadvar.}: EdClient
+  ## The thread's client, set by `Enu.client` so the other helpers don't need
+  ## a handle threaded through every call.
+
+proc client*(_: type Enu, address = "", mode = PARTIAL, id = ""): EdClient =
+  ## This thread's Enu client: created and stored on first call, returned as-is
+  ## on every call after — so `Enu.client` is a stable handle you can name
+  ## anywhere (`Enu.client.connect`, `Enu.client.tick`, ...) without threading
+  ## a variable around (later args are ignored once it exists). `address`
+  ## defaults to $ENU_CONNECT_ADDRESS, then "127.0.0.1"; `mode` defaults to
+  ## PARTIAL (on-demand, blocking reads) — the right default for a synchronous
+  ## tool. It starts unconnected; connect it once with `.connect`, which
+  ## bootstraps the Ed runtime at your call site:
+  ##
+  ##   Enu.client.connect
+  if enu_client.is_nil:
+    let resolved =
+      if address != "":
+        address
+      else:
+        get_env("ENU_CONNECT_ADDRESS", "127.0.0.1")
+    enu_client = EdClient(id: id, address: resolved, mode: mode)
+  enu_client
+
+proc units*(_: type Enu): EdSeq[Unit] =
+  ## The level's top-level units, via this thread's client.
+  EdSeq[Unit](enu_client.ctx["root_units"])
+
+proc find_unit*(_: type Enu, id: string): Unit =
+  ## The root unit with this `id`, or nil if there's no match.
+  for unit in Enu.units:
+    if unit.id == id:
+      return unit
+
+proc ask*(unit: Unit, q: UnitQuery, timeout = 30.seconds): UnitQuery =
+  ## File query `q` against `unit` and tick until Enu answers (or `timeout`).
+  let slot = unit.query(q)
+  if Enu.client.tick_until(timeout, slot.value.state == DONE):
+    return slot.value
+  unit.query = UnitQuery(state: DONE)
+  UnitQuery(state: DONE, error: "Error: Enu did not respond within " & $timeout)
+
+proc answer*(q: UnitQuery): string =
+  ## A query's result, or its error message.
+  if q.error != "": q.error else: q.result
+
+proc eval*(unit: Unit, code: string, top_level = false): string =
+  ## Run Nim `code` in `unit`'s scripting context; return the value or error.
+  answer unit.ask(UnitQuery(kind: EVAL, code: code, top_level: top_level))

--- a/tasks.nim
+++ b/tasks.nim
@@ -115,6 +115,15 @@ proc build_godot(target = target, cpu = cpu, opts = godot_opts, force = false) =
   with_dir "vendor/godot":
     exec &"{scons} custom_modules=../modules platform={target} arch={cpu} {cross_compile_opts}{opts} -j{cores}"
 
+proc build_mcp(opts = "", output = "bin/enu" & exe_ext) =
+  # The MCP/CLI server (`enu mcp`) — a standalone `--define:no_godot` binary,
+  # separate from the Godot-hosted game lib. `.mcp.json` points Claude at it.
+  p "Building MCP server..."
+  exec &"nim c -d:release {opts} -o:{output} bin/enu.nim"
+
+task build_mcp, "Build the MCP/CLI server (bin/enu)":
+  build_mcp()
+
 task ios_prereqs, "Build godot for ios":
   with_dir "vendor/pcre":
     exec "./configure  --host=arm-apple-darwin10 --target=arm-apple-darwin10"
@@ -148,6 +157,10 @@ task build, "Build enu":
       else:
         ""
   exec &"nim c -o:{output}{cross_opts}{extra} src/enu.nim"
+  # Also build the MCP server for dev runs. dist builds + bundles it per-platform
+  # below, so skip the redundant copy there.
+  if "-d:dist" notin command_line_params():
+    build_mcp()
 
 task build_godot, "Build godot. Use --force to re-init submodules":
   build_godot(force = "--force" in command_line_params())
@@ -318,7 +331,7 @@ task mcp_repro,
   for i in 1 .. iterations:
     echo &"\n--- Iteration {i}/{iterations} ---"
     let result = gorge_ex(
-      "ENU_CONNECT_ADDRESS=127.0.0.1 nim c -r bin/enu_mcp_test.nim 2>&1"
+      "ENU_CONNECT_ADDRESS=127.0.0.1 nim c -r tests/mcp/enu_mcp_test.nim 2>&1"
     )
     echo result.output
     if result.exit_code == 0:
@@ -341,6 +354,9 @@ task mcp_repro,
     quit 1
 
 task test, "run all tests":
+  # TODO: fold the MCP integration tests (tests/mcp/) into `nim test` once the
+  # MCP server can launch a private Enu instance on a free port. Until then they
+  # need a manually-running Enu — run them with `nim mcp_repro`.
   var failed: seq[string]
 
   echo "\n=== Running unit tests ===\n"
@@ -553,6 +569,10 @@ task dist_package, "Build distribution binaries":
     find_and_copy_dlls mingw_path(), root, gcc_dlls
     find_and_copy_dlls get_current_compiler_exe().parent_dir, root, nim_dlls
     copy_vmlib "vmlib", root & "/vmlib"
+    # MCP server — resolves to <root>/bin/enu.exe (lib_dir.parent/bin); the
+    # bin/ subdir avoids colliding with the enu.exe launcher at the root.
+    mk_dir root & "/bin"
+    build_mcp("", root & "/bin/enu.exe")
     with_dir "dist":
       exec &"zip -r enu-{git_version}-windows-x64.zip enu-{git_version}"
   elif host_os == "macosx":
@@ -595,6 +615,19 @@ task dist_package, "Build distribution binaries":
 
     copy_vmlib "vmlib", "dist/Enu.app/Contents/Resources/vmlib"
 
+    # MCP server, universal — resolves to <Resources>/bin/enu (lib_dir.parent/bin).
+    mk_dir "dist/Enu.app/Contents/Resources/bin"
+    build_mcp(
+      "--cpu:amd64 -l:'-target x86_64-apple-macos11' -t:'-target x86_64-apple-macos11'",
+      "dist/mcp.x86_64",
+    )
+    build_mcp(
+      "--cpu:arm64 -l:'-target arm64-apple-macos11' -t:'-target arm64-apple-macos11'",
+      "dist/mcp.arm64",
+    )
+    exec "lipo -create dist/mcp.x86_64 dist/mcp.arm64 -output dist/Enu.app/Contents/Resources/bin/enu"
+    exec "rm dist/mcp.x86_64 dist/mcp.arm64"
+
     if config["sign"].get_bool:
       let id = config["id"].get_str
       if "keychain" in config:
@@ -602,6 +635,7 @@ task dist_package, "Build distribution binaries":
         let password = config["keychain-password"].get_str
         exec &"security unlock-keychain -p \"{password}\" {keychain}"
       code_sign(id, "dist/Enu.app/Contents/Frameworks/enu.dylib")
+      code_sign(id, "dist/Enu.app/Contents/Resources/bin/enu")
       code_sign(id, "dist/Enu.app")
 
     let package_name = &"enu-{git_version}.dmg"
@@ -631,6 +665,10 @@ task dist_package, "Build distribution binaries":
     cp_file release_bin, root & "/bin/enu"
     cp_file "app/enu.so", root & "/lib/enu.so"
     copy_vmlib "vmlib", root & "/lib/vmlib"
+    # MCP server — resolves to <root>/lib/bin/enu (lib_dir.parent/bin).
+    mk_dir root & "/lib/bin"
+    build_mcp("", root & "/lib/bin/enu")
+    exec "chmod +x " & root & "/lib/bin/enu"
     exec "chmod +x " & root & "/bin/enu"
     exec &"{gen()} write_export_presets --enu_version {git_version}"
     let pck_path = this_dir() & "/" & root & "/enu.pck"

--- a/tests/mcp/config.nims
+++ b/tests/mcp/config.nims
@@ -1,0 +1,26 @@
+# MCP integration tests. These drive a *running* Enu over the client layer
+# (no_godot, like bin/enu.nim), so they aren't part of `nim test` yet — see the
+# TODO in tasks.nim. Run against a live Enu with `nim mcp_repro`.
+switch("path", "$projectDir/../../src")
+switch("path", "$projectDir/../../generated")
+switch("path", "$projectDir/../../vmlib")
+
+--threads:on
+--mm:orc
+--deepcopy:on
+--tls_emulation:off
+
+--define:no_godot
+--define:vmExecHooks
+--define:nimPreviewHashRef
+--define:nimTypeNames
+--define:ed_partial_subscriber
+
+# Chronicles config (match main project)
+--define:"chronicles_enabled=on"
+--define:"chronicles_log_level=INFO"
+--define:"chronicles_sinks=textlines[dynamic]"
+
+--experimental:dynamicBindSym
+--warning:"LockLevel:off"
+--warning:"UseBase:off"

--- a/tests/mcp/enu_mcp_reconnect_test.nim
+++ b/tests/mcp/enu_mcp_reconnect_test.nim
@@ -1,0 +1,222 @@
+## Reconnect test for enu_mcp.
+##
+## Tests that enu_mcp auto-reconnects after the netty connection times out
+## (10 seconds of inactivity causes Enu to silently drop the UDP connection).
+##
+## Run standalone:
+##   ENU_CONNECT_ADDRESS=127.0.0.1 nim c -r bin/enu_mcp_reconnect_test.nim
+##
+## Or via the full suite:
+##   ENU_CONNECT_ADDRESS=127.0.0.1 nim c -r bin/enu_mcp_test.nim
+
+import std/[osproc, streams, json, strutils, os, times]
+
+type McpSession = object
+  process: Process
+  next_id: int
+
+proc open_session(): McpSession =
+  result.process = start_process(
+    "nim", args = ["r", "./bin/enu.nim", "mcp"], options = {poUsePath}
+  )
+  result.next_id = 1
+
+proc close(s: var McpSession) =
+  s.process.terminate()
+  discard s.process.wait_for_exit(timeout = 2000)
+  s.process.close()
+  sleep 400
+
+proc send(s: McpSession, msg: JsonNode) =
+  s.process.input_stream.write($msg & "\n")
+  s.process.input_stream.flush()
+
+proc collect_stderr(s: McpSession): string =
+  try:
+    result = s.process.error_stream.read_all()
+  except:
+    discard
+
+proc recv(s: McpSession, timeout_ms = 20000): JsonNode =
+  let deadline = epoch_time() + timeout_ms.float / 1000.0
+  while epoch_time() < deadline:
+    let line =
+      try:
+        s.process.output_stream.read_line()
+      except IOError:
+        let err = s.collect_stderr()
+        echo "FAIL: process died (IOError). stderr (last 3000 chars):"
+        echo err[max(0, err.len - 3000) ..< err.len]
+        quit 1
+    if line == "":
+      sleep 10
+      continue
+    try:
+      result = parse_json(line)
+    except JsonParsingError:
+      # nimcp emits an "MCP server initialized" info line on stdout at boot.
+      # Skip non-JSON lines instead of failing the test.
+      continue
+    return
+  let err = s.collect_stderr()
+  echo "FAIL: timed out after " & $timeout_ms & "ms. stderr (last 3000 chars):"
+  echo err[max(0, err.len - 3000) ..< err.len]
+  quit 1
+
+proc send_recv(s: McpSession, msg: JsonNode, timeout_ms = 20000): JsonNode =
+  s.send(msg)
+  s.recv(timeout_ms)
+
+proc do_initialize(s: var McpSession) =
+  let id = s.next_id
+  inc s.next_id
+  let resp = s.send_recv(
+    %*{
+      "jsonrpc": "2.0",
+      "id": id,
+      "method": "initialize",
+      "params": {
+        "protocolVersion": "2024-11-05",
+        "capabilities": {},
+        "clientInfo": {"name": "test", "version": "1"},
+      },
+    }
+  )
+  if resp{"id"}.get_int != id or
+      (resp.has_key("error") and resp["error"].kind != JNull):
+    echo "FAIL: initialize failed: " & $resp
+    quit 1
+
+proc do_call_tool(s: var McpSession, name: string, args: JsonNode, timeout_ms = 20000): string =
+  let id = s.next_id
+  inc s.next_id
+  let resp = s.send_recv(
+    %*{
+      "jsonrpc": "2.0",
+      "id": id,
+      "method": "tools/call",
+      "params": {"name": name, "arguments": args},
+    },
+    timeout_ms,
+  )
+  if resp{"id"}.get_int != id:
+    echo "FAIL: id mismatch in tool response"
+    quit 1
+  if resp.has_key("error") and resp["error"].kind != JNull:
+    return "Error: " & $resp["error"]
+  let content = resp{"result"}{"content"}
+  if content.kind == JArray and content.len > 0:
+    result = content[0]{"text"}.get_str
+
+template check(cond: bool, msg: string) =
+  if not cond:
+    echo "FAIL: " & msg
+    quit 1
+
+proc run_reconnect_tests*() =
+  echo ""
+  echo "Reconnect tests (requires Enu with ENU_LISTEN_ADDRESS=127.0.0.1):"
+  discard exec_cmd_ex("pkill -x enu_mcp 2>/dev/null; true")
+  sleep 400
+
+  echo "  idle-reconnect: eval, wait 15s for netty timeout, eval again..."
+  stdout.flush_file()
+  block:
+    var s = open_session()
+    defer:
+      s.close()
+    s.do_initialize()
+    # Send all args: nimcp requires every declared tool param in the JSON,
+    # else the call errors `key not found: <param>` (its error JSON happens
+    # to contain the requestId, so a bare `"1" in r1` would pass on an
+    # error). Full args make this verify eval execution, not just a reply.
+    let r1 = s.do_call_tool(
+      "eval", %*{"code": "1", "top_level": false, "unit_id": ""}
+    )
+    check r1 == "1", "initial eval failed: " & r1
+
+    echo "    (waiting 15s for netty 10s timeout + margin...)"
+    stdout.flush_file()
+    sleep 15_000
+
+    let r2 = s.do_call_tool(
+      "eval", %*{"code": "2", "top_level": false, "unit_id": ""},
+      timeout_ms = 30_000,
+    )
+    check r2 == "2", "post-timeout eval failed: " & r2
+    echo "  idle-reconnect: PASS"
+
+  echo "  idle-reconnect set_position: connect, wait 15s, move bot..."
+  stdout.flush_file()
+  block:
+    var s = open_session()
+    defer:
+      s.close()
+    s.do_initialize()
+    let r1 = s.do_call_tool("eval", %*{"code": "1"})
+    check "1" in r1, "initial eval failed: " & r1
+
+    echo "    (waiting 15s...)"
+    stdout.flush_file()
+    sleep 15_000
+
+    let r2 = s.do_call_tool(
+      "set_position",
+      %*{"x": 3.0, "y": 1.0, "z": -15.0, "rotation": 0.0, "id": ""},
+      timeout_ms = 30_000,
+    )
+    check not r2.starts_with("Error"), "post-timeout set_position failed: " & r2
+    echo "  idle-reconnect set_position: PASS"
+
+  echo "  fast-reconnect: 8 fresh sessions back-to-back, no own-message assert..."
+  stdout.flush_file()
+  # Before the SUBSCRIBE-time stale-sub sweep landed, each fresh enu_mcp
+  # process subscribing to Enu within netty's ~10s keepalive window had a
+  # ~7/8 chance of tripping the `self.id notin source` assert in ed on the
+  # first ASSIGN-publishing tool call (set_position, screenshot_at, eval).
+  # With stable per-process ctx ids plus the worker-side sweep on
+  # SUBSCRIBE, this loop should run clean.
+  for i in 1 .. 8:
+    var s = open_session()
+    s.do_initialize()
+    case i mod 4
+    of 1:
+      let r = s.do_call_tool(
+        "set_position",
+        %*{"x": 5.0, "y": 1.0, "z": -10.0, "rotation": 0.0, "id": ""},
+        timeout_ms = 15_000,
+      )
+      check not r.starts_with("Error"), "iter " & $i & " set_position: " & r
+    of 2:
+      let r = s.do_call_tool(
+        "screenshot_at",
+        %*{
+          "x": 0.0, "y": 1.0, "z": -10.0,
+          "distance": 20.0, "height": 10.0, "angle": 180.0,
+        },
+        timeout_ms = 20_000,
+      )
+      check not r.starts_with("Error"), "iter " & $i & " screenshot_at: " & r
+    of 3:
+      let r = s.do_call_tool(
+        "screenshot_top_down",
+        %*{"x": 0.0, "z": -10.0, "size": 30.0},
+        timeout_ms = 20_000,
+      )
+      check not r.starts_with("Error"),
+        "iter " & $i & " screenshot_top_down: " & r
+    else:
+      let r = s.do_call_tool(
+        "eval",
+        %*{"code": "1", "top_level": false, "unit_id": ""},
+        timeout_ms = 15_000,
+      )
+      check not r.starts_with("Error"), "iter " & $i & " eval: " & r
+    s.close()
+  echo "  fast-reconnect: PASS"
+
+when is_main_module:
+  echo "=== enu_mcp reconnect test ==="
+  run_reconnect_tests()
+  echo ""
+  echo "=== All reconnect tests passed ==="

--- a/tests/mcp/enu_mcp_test.nim
+++ b/tests/mcp/enu_mcp_test.nim
@@ -1,0 +1,516 @@
+## Test harness for enu_mcp. Run with:
+##   nim c -r bin/enu_mcp_test.nim
+##
+## Integration tests (eval/screenshot/get_console) require Enu running with:
+##   ENU_LISTEN_ADDRESS=127.0.0.1 nim start
+##
+## Verifies:
+##   - All stdout lines are valid JSON (logging to stdout = test failure)
+##   - Stderr output does not corrupt stdout
+##   - JSON-RPC ids round-trip correctly
+##   - Tool results have the expected structure
+
+import std/[osproc, streams, json, strutils, os, times, md5]
+import enu_mcp_reconnect_test
+
+type McpSession = object
+  process: Process
+  next_id: int
+
+proc open_session(): McpSession =
+  result.process = start_process(
+    "nim", args = ["r", "./bin/enu.nim", "mcp"], options = {poUsePath}
+  )
+  result.next_id = 1
+
+proc close(s: var McpSession) =
+  s.process.terminate()
+  discard s.process.wait_for_exit(timeout = 2000)
+  s.process.close()
+  # Give Enu time to detect the disconnect before the next session connects
+  sleep 400
+
+proc send(s: McpSession, msg: JsonNode) =
+  s.process.input_stream.write($msg & "\n")
+  s.process.input_stream.flush()
+
+proc dump_stderr(s: McpSession) =
+  try:
+    let err = s.process.error_stream.read_all()
+    if err != "":
+      echo "--- stderr ---"
+      echo err[0 ..< min(1000, err.len)]
+      echo "--------------"
+  except:
+    discard
+
+proc recv(s: McpSession, timeout_ms = 8000): JsonNode =
+  let deadline = epoch_time() + timeout_ms.float / 1000.0
+  while epoch_time() < deadline:
+    let line =
+      try:
+        s.process.output_stream.read_line()
+      except IOError:
+        s.dump_stderr()
+        echo "FAIL: process died (IOError reading stdout)"
+        quit 1
+    if line == "":
+      sleep 10
+      continue
+    # Any non-JSON on stdout is a test failure
+    try:
+      result = parse_json(line)
+    except JsonParsingError as e:
+      echo "FAIL: non-JSON on stdout: " & e.msg
+      echo "  raw: " & line[0 ..< min(300, line.len)]
+      quit 1
+    return
+  echo "FAIL: timed out after " & $timeout_ms & "ms waiting for response"
+  s.dump_stderr()
+  quit 1
+
+proc send_recv(s: McpSession, msg: JsonNode, timeout_ms = 8000): JsonNode =
+  s.send(msg)
+  s.recv(timeout_ms)
+
+proc check_id(response: JsonNode, id: int) =
+  if response{"id"}.get_int != id:
+    echo "FAIL: expected id=" & $id & " got id=" & $response{"id"}
+    quit 1
+
+proc check_ok(response: JsonNode) =
+  if response.has_key("error") and response["error"].kind != JNull:
+    echo "FAIL: unexpected error: " & $response["error"]
+    quit 1
+
+proc check_error(response: JsonNode) =
+  if not (response.has_key("error") and response["error"].kind != JNull):
+    echo "FAIL: expected error but got: " & $response
+    quit 1
+
+proc do_initialize(s: var McpSession): JsonNode =
+  let id = s.next_id
+  inc s.next_id
+  result = s.send_recv(
+    %*{
+      "jsonrpc": "2.0",
+      "id": id,
+      "method": "initialize",
+      "params": {
+        "protocolVersion": "2024-11-05",
+        "capabilities": {},
+        "clientInfo": {"name": "test", "version": "1"},
+      },
+    }
+  )
+  result.check_id(id)
+  result.check_ok()
+
+proc do_list_tools(s: var McpSession): JsonNode =
+  let id = s.next_id
+  inc s.next_id
+  result = s.send_recv(
+    %*{"jsonrpc": "2.0", "id": id, "method": "tools/list", "params": {}}
+  )
+  result.check_id(id)
+  result.check_ok()
+
+proc do_call_tool(
+    s: var McpSession, name: string, args: JsonNode, timeout_ms = 12000
+): JsonNode =
+  let id = s.next_id
+  inc s.next_id
+  result = s.send_recv(
+    %*{
+      "jsonrpc": "2.0",
+      "id": id,
+      "method": "tools/call",
+      "params": {"name": name, "arguments": args},
+    },
+    timeout_ms,
+  )
+  result.check_id(id)
+  result.check_ok()
+
+proc tool_text(response: JsonNode): string =
+  let content = response{"result"}{"content"}
+  if content.kind != JArray or content.len == 0:
+    echo "FAIL: expected content array, got: " & $response
+    quit 1
+  result = content[0]{"text"}.get_str
+
+# ---- Tests ----------------------------------------------------------------
+
+template test(name: string, body: untyped) =
+  stdout.write "  " & name & "... "
+  stdout.flush_file()
+  block:
+    body
+  echo "PASS"
+
+proc run_protocol_tests() =
+  echo "Protocol tests (no Enu required):"
+
+  test "initialize returns valid protocolVersion":
+    var s = open_session()
+    defer:
+      s.close()
+    let resp = s.do_initialize()
+    let proto = resp{"result"}{"protocolVersion"}.get_str
+    if proto == "":
+      echo "FAIL: missing protocolVersion"
+      quit 1
+
+  test "initialize serverInfo.name is 'enu'":
+    var s = open_session()
+    defer:
+      s.close()
+    let resp = s.do_initialize()
+    if resp{"result"}{"serverInfo"}{"name"}.get_str != "enu":
+      echo "FAIL: wrong server name"
+      quit 1
+
+  test "tools/list returns eval, get_console, screenshot":
+    var s = open_session()
+    defer:
+      s.close()
+    discard s.do_initialize()
+    let resp = s.do_list_tools()
+    let tools = resp{"result"}{"tools"}
+    if tools.kind != JArray:
+      echo "FAIL: tools is not an array"
+      quit 1
+    var names: seq[string]
+    for t in tools:
+      names.add t{"name"}.get_str
+    for expected in ["eval", "get_console", "screenshot", "set_position"]:
+      if expected notin names:
+        echo "FAIL: missing tool: " & expected
+        quit 1
+
+  test "each tool has description and inputSchema":
+    var s = open_session()
+    defer:
+      s.close()
+    discard s.do_initialize()
+    let resp = s.do_list_tools()
+    for tool in resp{"result"}{"tools"}:
+      let n = tool{"name"}.get_str
+      if tool{"description"}.get_str == "":
+        echo "FAIL: tool '" & n & "' missing description"
+        quit 1
+      if not tool.has_key("inputSchema"):
+        echo "FAIL: tool '" & n & "' missing inputSchema"
+        quit 1
+
+  test "unknown method returns JSON-RPC error":
+    var s = open_session()
+    defer:
+      s.close()
+    discard s.do_initialize()
+    let id = s.next_id
+    inc s.next_id
+    let resp = s.send_recv(
+      %*{"jsonrpc": "2.0", "id": id, "method": "no_such_method", "params": {}}
+    )
+    resp.check_id(id)
+    resp.check_error()
+
+  test "multiple initialize calls each return valid responses":
+    for _ in 1 .. 3:
+      var s = open_session()
+      defer:
+        s.close()
+      let resp = s.do_initialize()
+      if resp{"result"}{"protocolVersion"}.get_str == "":
+        echo "FAIL: missing protocolVersion"
+        quit 1
+
+  test "eval tool has 'code' parameter in schema":
+    var s = open_session()
+    defer:
+      s.close()
+    discard s.do_initialize()
+    let resp = s.do_list_tools()
+    for tool in resp{"result"}{"tools"}:
+      if tool{"name"}.get_str == "eval":
+        let props = tool{"inputSchema"}{"properties"}
+        if not props.has_key("code"):
+          echo "FAIL: eval missing 'code' property"
+          quit 1
+
+  test "response ids match request ids":
+    var s = open_session()
+    defer:
+      s.close()
+    discard s.do_initialize()
+    # Send two requests, verify ids are correct
+    let id1 = s.next_id
+    inc s.next_id
+    let id2 = s.next_id
+    inc s.next_id
+    s.send(
+      %*{"jsonrpc": "2.0", "id": id1, "method": "tools/list", "params": {}}
+    )
+    s.send(
+      %*{"jsonrpc": "2.0", "id": id2, "method": "tools/list", "params": {}}
+    )
+    let r1 = s.recv()
+    let r2 = s.recv()
+    let got = [r1{"id"}.get_int, r2{"id"}.get_int]
+    if id1 notin got or id2 notin got:
+      echo "FAIL: id mismatch"
+      quit 1
+
+proc run_integration_tests() =
+  echo ""
+  echo "Integration tests (requires Enu with ENU_LISTEN_ADDRESS=127.0.0.1):"
+  # Kill any stale enu_mcp processes left from a previous run
+  discard exec_cmd_ex("pkill -x enu_mcp 2>/dev/null; true")
+  sleep 400
+
+  test "eval: 42 expression returns '42'":
+    var s = open_session()
+    defer:
+      s.close()
+    discard s.do_initialize()
+    let text = s.do_call_tool("eval", %*{"code": "42"}).tool_text
+    if "42" notin text:
+      echo "FAIL: expected '42' in output, got: " & text
+      quit 1
+
+  test "eval: 3 sequential calls all succeed":
+    var s = open_session()
+    defer:
+      s.close()
+    discard s.do_initialize()
+    for i in 1 .. 3:
+      let text = s.do_call_tool("eval", %*{"code": $i}).tool_text
+      if $i notin text:
+        echo "FAIL: call " & $i & " got: " & text
+        quit 1
+
+  test "eval: same session, multiple tool calls stay live":
+    var s = open_session()
+    defer:
+      s.close()
+    discard s.do_initialize()
+    for i in 1 .. 5:
+      let text =
+        s.do_call_tool("eval", %*{"code": "\"ping" & $i & "\""}).tool_text
+      if "ping" & $i notin text:
+        echo "FAIL: call " & $i & " got: " & text
+        quit 1
+
+  test "get_console returns output from prior eval":
+    var s = open_session()
+    defer:
+      s.close()
+    discard s.do_initialize()
+    discard s.do_call_tool("eval", %*{"code": "echo \"console_marker_xyz\""})
+    let text = s.do_call_tool("get_console", %*{}).tool_text
+    if "console_marker_xyz" notin text:
+      echo "FAIL: marker not found in console: " & text
+      quit 1
+
+  test "screenshot returns a .png file path":
+    var s = open_session()
+    defer:
+      s.close()
+    discard s.do_initialize()
+    let text = s.do_call_tool("screenshot", %*{}, timeout_ms = 20000).tool_text
+    if not text.ends_with(".png"):
+      echo "FAIL: expected .png path, got: " & text[0 ..< min(100, text.len)]
+      quit 1
+    echo "(path: " & text & ") "
+
+  test "screenshot then eval: server stays alive after screenshot":
+    var s = open_session()
+    defer:
+      s.close()
+    discard s.do_initialize()
+    discard s.do_call_tool("screenshot", %*{}, timeout_ms = 20000)
+    let text =
+      s.do_call_tool("eval", %*{"code": "echo after_screenshot"}).tool_text
+    if "after_screenshot" notin text:
+      echo "FAIL: eval after screenshot failed, got: " & text
+      quit 1
+
+  test "eval player.position = vec3(0, 5, -30)":
+    var s = open_session()
+    defer:
+      s.close()
+    discard s.do_initialize()
+    let resp = s.do_call_tool(
+      "eval",
+      %*{"code": "player.position = vec3(0, 5, -30)"},
+      timeout_ms = 30000,
+    )
+    let text = resp.tool_text
+    echo "(result: '" & text & "') "
+
+  test "set_position moves MCP bot (no id = default bot)":
+    var s = open_session()
+    defer:
+      s.close()
+    discard s.do_initialize()
+    let text = s.do_call_tool(
+      "set_position", %*{"x": 0.0, "y": 1.0, "z": -40.0}, timeout_ms = 20000
+    ).tool_text
+    if text.starts_with("Error"):
+      echo "FAIL: " & text
+      quit 1
+
+  test "set_position with rotation":
+    var s = open_session()
+    defer:
+      s.close()
+    discard s.do_initialize()
+    let text = s.do_call_tool(
+      "set_position",
+      %*{"x": 5.0, "y": 1.0, "z": -40.0, "rotation": 90.0},
+      timeout_ms = 20000,
+    ).tool_text
+    if text.starts_with("Error"):
+      echo "FAIL: " & text
+      quit 1
+
+  test "set_position then screenshot shows new perspective":
+    var s = open_session()
+    defer:
+      s.close()
+    discard s.do_initialize()
+    discard s.do_call_tool(
+      "set_position", %*{"x": 0.0, "y": 1.0, "z": -35.0}, timeout_ms = 20000
+    )
+    let shot1 = s.do_call_tool("screenshot", %*{}, timeout_ms = 20000).tool_text
+    if not shot1.ends_with(".png"):
+      echo "FAIL: expected .png, got: " & shot1[0 ..< min(100, shot1.len)]
+      quit 1
+    discard s.do_call_tool(
+      "set_position", %*{"x": 0.0, "y": 50.0, "z": -35.0}, timeout_ms = 20000
+    )
+    let shot2 = s.do_call_tool("screenshot", %*{}, timeout_ms = 20000).tool_text
+    if not shot2.ends_with(".png"):
+      echo "FAIL: expected .png, got: " & shot2[0 ..< min(100, shot2.len)]
+      quit 1
+    let hash1 = get_md5(read_file(shot1))
+    let hash2 = get_md5(read_file(shot2))
+    if hash1 == hash2:
+      echo "FAIL: screenshots from y=1 and y=50 are identical (camera not updating)"
+      quit 1
+    echo "(images differ) "
+
+  test "set_position: 3 sequential moves":
+    var s = open_session()
+    defer:
+      s.close()
+    discard s.do_initialize()
+    let positions = [(0.0, 1.0, -38.0), (3.0, 1.0, -42.0), (-3.0, 1.0, -40.0)]
+    for (x, y, z) in positions:
+      let text = s.do_call_tool(
+        "set_position", %*{"x": x, "y": y, "z": z}, timeout_ms = 20000
+      ).tool_text
+      if text.starts_with("Error"):
+        echo "FAIL: move to (" & $x & "," & $y & "," & $z & "): " & text
+        quit 1
+
+  test "10 sequential move+screenshot pairs all show distinct images":
+    var s = open_session()
+    defer:
+      s.close()
+    discard s.do_initialize()
+    let ys = [1.0, 10.0, 20.0, 5.0, 40.0, 2.0, 30.0, 8.0, 15.0, 50.0]
+    var prev_hash = ""
+    for i, y in ys:
+      discard s.do_call_tool(
+        "set_position", %*{"x": 0.0, "y": y, "z": -35.0}, timeout_ms = 20000
+      )
+      let shot = s.do_call_tool("screenshot", %*{}, timeout_ms = 20000).tool_text
+      if not shot.ends_with(".png"):
+        echo "FAIL: screenshot " & $i & " expected .png, got: " &
+          shot[0 ..< min(80, shot.len)]
+        quit 1
+      let hash = get_md5(read_file(shot))
+      if hash == prev_hash:
+        echo "FAIL: screenshot " & $i & " (y=" & $y &
+          ") identical to previous (camera not updating)"
+        quit 1
+      prev_hash = hash
+    echo "(10 distinct images) "
+
+  test "stress: 25 alternating screenshot+eval calls all complete":
+    var s = open_session()
+    defer:
+      s.close()
+    discard s.do_initialize()
+    for i in 1 .. 25:
+      let shot =
+        s.do_call_tool("screenshot", %*{}, timeout_ms = 15000).tool_text
+      if not shot.ends_with(".png"):
+        echo "FAIL: screenshot " & $i & " failed, got: " &
+          shot[0 ..< min(80, shot.len)]
+        quit 1
+      let ev =
+        s.do_call_tool("eval", %*{"code": $i}, timeout_ms = 15000).tool_text
+      if $i notin ev:
+        echo "FAIL: eval " & $i & " got: " & ev[0 ..< min(80, ev.len)]
+        quit 1
+    echo "(50 tool calls) "
+
+proc run_hang_repro() =
+  echo ""
+  echo "Hang repro (loops until hang or 500 calls):"
+  echo "  eval+screenshot loop..."
+  stdout.flush_file()
+
+  var s = open_session()
+  defer:
+    s.close()
+  discard s.do_initialize()
+
+  var call = 0
+  while call < 500:
+    inc call
+    let ev =
+      s.do_call_tool("eval", %*{"code": $call}, timeout_ms = 35000).tool_text
+    if $call notin ev:
+      echo ""
+      echo "FAIL: eval " & $call & " got: " & ev[0 ..< min(80, ev.len)]
+      quit 1
+    stdout.write $call & "e "
+    stdout.flush_file()
+
+    let shot = s.do_call_tool("screenshot", %*{}, timeout_ms = 35000).tool_text
+    if not shot.ends_with(".png"):
+      echo ""
+      echo "FAIL: screenshot after eval " & $call & " got: " &
+        shot[0 ..< min(80, shot.len)]
+      quit 1
+    stdout.write $call & "s "
+    stdout.flush_file()
+
+  echo ""
+  echo "  PASS (500 calls without hang)"
+
+# ---- Main -----------------------------------------------------------------
+
+let is_integration =
+  get_env("ENU_CONNECT_ADDRESS", "") != "" or
+  get_env("ENU_LISTEN_ADDRESS", "") != ""
+
+echo "=== enu_mcp test suite ==="
+echo ""
+
+run_protocol_tests()
+
+if is_integration:
+  run_integration_tests()
+  run_reconnect_tests()
+  run_hang_repro()
+else:
+  echo ""
+  echo "(skipping integration tests — run with ENU_LISTEN_ADDRESS=127.0.0.1)"
+
+echo ""
+echo "=== All tests passed ==="


### PR DESCRIPTION
Part 2 of the `mcp-server` split (replaces #57, which GitHub auto-closed when its base `split/foundation` — now merged via #56 — was deleted). **Base: `main`.**

A standalone `enu mcp` server (`--define:no_godot`, nimcp) that drives a running Enu over `ed` through a thin client layer, with example clients, MCP integration tests, and the build wiring to compile and bundle the binary.

Stacked under it: #58 (agent files & Claude plugin).