### PR TITLE
MCP managed Enu instances + fast/full test split

### DIFF
--- a/.github/workflows/dist_linux.yaml
+++ b/.github/workflows/dist_linux.yaml
@@ -45,13 +45,13 @@ jobs:
       - name: Dist
         run: nim dist_package
       - name: Run unit tests
-        run: nim unit_tests
+        run: nim test_unit
       - name: Run VM tests
-        run: nim vm_tests
+        run: nim test_vm
       - name: Rebuild for headless tests
         run: nim build
       - name: Run world tests
-        run: nim world_tests headless
+        run: nim test_world headless
       - uses: actions/upload-artifact@v4
         with:
           name: Enu Linux Distribution

--- a/.github/workflows/dist_mac.yaml
+++ b/.github/workflows/dist_mac.yaml
@@ -71,11 +71,11 @@ jobs:
       - name: Dist
         run: nim dist_package
       - name: Run unit tests
-        run: nim unit_tests
+        run: nim test_unit
       - name: Run VM tests
-        run: nim vm_tests
+        run: nim test_vm
       - name: Run world tests
-        run: nim world_tests dist
+        run: nim test_world dist
       - uses: actions/upload-artifact@v4
         with:
           name: Enu macOS Distribution

--- a/.github/workflows/dist_win.yaml
+++ b/.github/workflows/dist_win.yaml
@@ -64,12 +64,12 @@ jobs:
       - name: Dist
         run: nim dist_package
       - name: Run unit tests
-        run: nim unit_tests
+        run: nim test_unit
       - name: Run VM tests
-        run: nim vm_tests
-      # world_tests disabled on Windows - no headless support until Godot 4
+        run: nim test_vm
+      # test_world disabled on Windows - no headless support until Godot 4
       # - name: Run world tests
-      #   run: nim world_tests dist
+      #   run: nim test_world dist
 
       # Upload unsigned dist for zip signing
       - name: Upload unsigned dist for zip signing

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -36,9 +36,12 @@ Enu is a 3D sandbox environment for creating and exploring voxel worlds using a 
 - `nim dist_package` - Package distribution binaries
 
 ### Testing and Documentation
-- `nim test` - Run all tests
-- `nim unit_tests` - Run unit tests
-- `nim vm_tests` - Run VM script tests
+- `nim test` - Run the fast default tests (unit + VM) — use while iterating
+- `nim test_all` - Run the full suite (unit + VM + world + MCP) — before opening a PR
+- `nim test_unit` - Run unit tests
+- `nim test_vm` - Run VM script tests
+- `nim test_world` - Run in-world tests (boots Godot)
+- `nim test_mcp` - Run MCP integration tests (launches a private Enu)
 - `nim docs` - Build documentation using nimibook
 - `nim clean` - Remove build artifacts
 

--- a/bin/enu.nim
+++ b/bin/enu.nim
@@ -279,6 +279,31 @@ let enu_server = mcp_server("enu", "1.0.0"):
         unit.glide(vec3(x, y, z), rotation, instant = not server_mode)
         ""
 
+  mcp_tool:
+    proc launch_enu(level_dir: string, port: int = 0): string =
+      ## Launch your own private Enu that opens `level_dir`, on a random free
+      ## port (or `port`), and connect to it. Use this when working on your own;
+      ## when collaborating, connect to the Enu the user is running instead.
+      ## Starts minimized. Returns the address.
+      if Enu.managing:
+        mark_tool_error()
+        return "Error: already managing an Enu — kill_enu first"
+      try:
+        "connected at " & Enu.launch(level_dir, port, id = ctx_id)
+      except CatchableError as e:
+        mark_tool_error()
+        "Error: " & e.msg
+
+  mcp_tool:
+    proc kill_enu(): string =
+      ## Terminate the Enu you launched with launch_enu and disconnect. Only
+      ## affects an instance you started.
+      if not Enu.managing:
+        mark_tool_error()
+        return "Error: no managed Enu to kill"
+      Enu.kill()
+      "killed"
+
 proc remove_bots() =
   if Enu.client.connected:
     for unit in Enu.units.value:
@@ -294,6 +319,9 @@ if server_mode:
     idle = proc() =
       Enu.client.tick,
   )
+  # Don't orphan a managed Enu when the client disconnects and serve returns.
+  if Enu.managing:
+    Enu.kill()
 elif cli_args.len == 0 or cli_args[0] in ["help", "--help", "-h"]:
   echo "enu — drive a running Enu from the command line.\n"
   echo enu_server.help_text("enu")

--- a/src/client.nim
+++ b/src/client.nim
@@ -6,7 +6,7 @@
 ##
 ## This is purely an app-facing helper — regular Enu doesn't use it.
 
-import std/os
+import std/[os, osproc, net, strutils, sequtils]
 import pkg/ed
 import core, models/units
 
@@ -63,3 +63,121 @@ proc answer*(q: UnitQuery): string =
 proc eval*(unit: Unit, code: string, top_level = false): string =
   ## Run Nim `code` in `unit`'s scripting context; return the value or error.
   answer unit.ask(UnitQuery(kind: EVAL, code: code, top_level: top_level))
+
+# --- Managed Enu instances -------------------------------------------------
+# Launch and own an Enu process, rather than connecting to one the user is
+# running. Backs the MCP server's launch_enu/kill_enu tools and the MCP
+# integration tests: an agent (or a test) can stand up a private Enu on a
+# random port and tear it down again.
+
+var enu_process {.threadvar.}: Process
+  ## The Enu we launched, if any. Only this process may be `Enu.kill`ed — we
+  ## never touch an Enu the user is running.
+
+const exe_ext = when defined(windows): ".exe" else: ""
+
+proc free_port(): int =
+  ## Ask the OS for a free UDP port on loopback, then release it so the caller
+  ## can bind it — avoids colliding with a hard-coded port. (Duplicated from
+  ## ed's test_util; will move into ed once its current work settles.)
+  let s = new_socket(AF_INET, SOCK_DGRAM, IPPROTO_UDP)
+  defer:
+    s.close()
+  s.bind_addr(Port(0), "127.0.0.1")
+  int(s.get_local_addr()[1])
+
+proc launch_spec(): tuple[exe, workdir: string, args: seq[string]] =
+  ## Where the Enu to launch lives — static per dev/dist build and OS, with an
+  ## `ENU_EXE` override. Dev runs the in-tree Godot binary on the game scene; a
+  ## dist build runs the packaged executable bundled alongside us.
+  when defined(dist):
+    let bin_dir = get_app_filename().parent_dir
+    when defined(macosx):
+      # …/Contents/Resources/bin/enu -> …/Contents/MacOS/Enu
+      result =
+        (bin_dir.parent_dir.parent_dir / "MacOS" / "Enu", bin_dir.parent_dir, @[])
+    elif defined(windows):
+      result = (bin_dir / ("enu" & exe_ext), bin_dir, @[])
+    else:
+      # linux: …/lib/bin/enu -> …/bin/enu  (TODO: confirm dist layout)
+      result = (
+        bin_dir.parent_dir.parent_dir / "bin" / "enu",
+        bin_dir.parent_dir.parent_dir,
+        @[],
+      )
+  else:
+    const
+      repo = current_source_path().parent_dir.parent_dir
+      target =
+        when defined(macosx): "osx"
+        elif defined(windows): "windows"
+        else: "x11"
+      cpu = when host_cpu == "arm64": "arm64" else: "64"
+      godot =
+        repo / "vendor" / "godot" / "bin" /
+        ("godot." & target & ".tools." & cpu & exe_ext)
+    result = (godot, repo / "app", @["scenes/game.tscn"])
+  let override = get_env("ENU_EXE")
+  if override != "":
+    result.exe = override
+
+proc disconnect*(_: type Enu) =
+  ## Close and drop the client so the next `Enu.client` / `Enu.launch` opens a
+  ## fresh connection (to a possibly different address).
+  if not enu_client.is_nil:
+    if not enu_client.ctx.is_nil:
+      enu_client.ctx.close
+    enu_client = nil
+
+proc kill*(_: type Enu) =
+  ## Terminate the Enu we launched and disconnect. Raises if we don't manage
+  ## one.
+  if enu_process.is_nil:
+    raise ValueError.init("No managed Enu to kill")
+  enu_process.terminate()
+  discard enu_process.wait_for_exit(timeout = 3000)
+  if enu_process.running:
+    enu_process.kill()
+    discard enu_process.wait_for_exit()
+  enu_process.close()
+  enu_process = nil
+  Enu.disconnect
+
+proc launch*(
+    _: type Enu, level_dir: string, port = 0, id = "", timeout = 30.seconds
+): string =
+  ## Launch a managed Enu that opens `level_dir`, listening on `port` (0 = a
+  ## random free port), connect to it, and return its "host:port" address. The
+  ## window starts minimized. `level_dir` is required: a managed instance always
+  ## opens a specific level rather than whatever was last saved.
+  if level_dir == "":
+    raise ValueError.init("Enu.launch requires a level_dir")
+  Enu.disconnect
+  let
+    p = if port == 0: free_port() else: port
+    address = "127.0.0.1:" & $p
+    spec = launch_spec()
+    flags = @["--level-dir", level_dir, "--listen", address, "--minimized"]
+    log = get_temp_dir() / "enu_managed.log"
+  when defined(windows):
+    # TODO: Windows managed launch (no /bin/sh; needs output redirection).
+    raise ValueError.init("Managed Enu launch is not yet supported on Windows")
+  else:
+    # Run via the shell with `exec` so the child PID is Enu itself (directly
+    # killable) and its noisy stdout/stderr land in a log rather than corrupting
+    # our own stdout — which, for the MCP server, is the JSON-RPC channel.
+    let cmd =
+      "exec " & quote_shell(spec.exe) & " " &
+      (spec.args & flags).map(quote_shell).join(" ") & " > " & quote_shell(log) &
+      " 2>&1"
+    enu_process =
+      start_process("/bin/sh", working_dir = spec.workdir, args = ["-c", cmd])
+  Enu.client(address = address, id = id).connect
+  if not Enu.client.tick_until(timeout, Enu.client.connected):
+    Enu.kill()
+    raise ValueError.init("Launched Enu but could not connect at " & address)
+  address
+
+proc managing*(_: type Enu): bool =
+  ## Whether we currently own a launched Enu.
+  not enu_process.is_nil

--- a/src/game.nim
+++ b/src/game.nim
@@ -229,6 +229,7 @@ gdobj Game of Node:
     var listen_address_override = ""
     var level_dir_override = ""
     var test_mode = false
+    var minimized = false
 
     block:
       let i = args.find("--connect")
@@ -253,6 +254,11 @@ gdobj Game of Node:
       let i = args.find("--enu-test")
       if i > -1:
         test_mode = true
+        args.delete(i)
+    block:
+      let i = args.find("--minimized")
+      if i > -1:
+        minimized = true
         args.delete(i)
     block:
       let i = args.find("--level")
@@ -354,7 +360,13 @@ gdobj Game of Node:
 
     state.set_flag(GOD, uc.god_mode ||= false)
 
-    set_window_fullscreen state.config.full_screen
+    if minimized:
+      # Launch out of the way (test runs, MCP-managed instances): minimize and
+      # skip fullscreen. The screenshot path force-draws a minimized window, so
+      # captures still work.
+      set_window_minimized true
+    else:
+      set_window_fullscreen state.config.full_screen
     when defined(metrics):
       let metrics_port =
         if ?get_env("ENU_METRICS_PORT"):

--- a/tasks.nim
+++ b/tasks.nim
@@ -220,10 +220,10 @@ task world_tests,
     p &"Running world test: {test_level.split_path.tail}"
     let cmd =
       if use_dist:
-        bin & " --level-dir " & test_level & " --enu-test --temp-workdir"
+        bin & " --level-dir " & test_level & " --enu-test --minimized --temp-workdir"
       else:
         "cd app && " & bin & " --level-dir " & test_level &
-          " --enu-test scenes/game.tscn --temp-workdir"
+          " --enu-test --minimized scenes/game.tscn --temp-workdir"
     exec cmd
 
 task client_smoke,

--- a/tasks.nim
+++ b/tasks.nim
@@ -168,21 +168,21 @@ task build_godot, "Build godot. Use --force to re-init submodules":
 task build_headless, "build headless godot":
   build_godot(target = "server use_static_cpp=no")
 
-task unit_tests, "run unit tests":
+task test_unit, "run unit tests":
   exec "nim c -r tests/unit/script_ctx_test"
   exec "nim c -r tests/unit/serializers_test"
   exec "nim c -r tests/unit/dependency_graph_test"
 
-task vm_tests, "run VM script tests":
+task test_vm, "run VM script tests":
   exec "nim c -r tests/vm/runner"
 
-task godot_tests, "run godot tests":
+task test_godot, "run godot tests":
   exec "nim c tests/godot/tnode_factories"
   cd "tests/godot/app"
   exec this_dir() /
     &"vendor/godot/bin/godot_server.osx.opt.tools.{cpu} --quiet --script tests/tests.gdns"
 
-task world_tests,
+task test_world,
   "run in-world tests (headless for server build, dist for dist build)":
   # Each level runs in sequence via `--enu-test`; test mode exits with a code
   # derived from script errors and signal_test_complete calls, and a non-zero
@@ -353,45 +353,32 @@ task mcp_repro,
   if fail_count > 0:
     quit 1
 
-task mcp_tests, "run MCP integration tests (launches a private Enu)":
+task test_mcp, "run MCP integration tests (launches a private Enu)":
   # The test self-launches a minimized Enu on a free port and tears it down, so
-  # no manually-running Enu is needed. Assumes the app is built, as `nim test`
-  # does for the world tests.
+  # no manually-running Enu is needed. Assumes the app is already built.
   exec "nim c -r tests/mcp/enu_mcp_test.nim"
 
-task test, "run all tests":
+proc run_tests(names: openArray[string]) =
+  ## Run each `nim <name>` task in turn, echo its output, and fail the whole
+  ## run (quit 1) if any of them fail.
   var failed: seq[string]
-
-  echo "\n=== Running unit tests ===\n"
-  let unit_result = gorge_ex("nim unit_tests")
-  echo unit_result.output
-  if unit_result.exit_code != 0:
-    failed.add "unit_tests"
-
-  echo "\n=== Running VM tests ===\n"
-  let vm_result = gorge_ex("nim vm_tests")
-  echo vm_result.output
-  if vm_result.exit_code != 0:
-    failed.add "vm_tests"
-
-  echo "\n=== Running world tests ===\n"
-  let world_result = gorge_ex("nim world_tests")
-  echo world_result.output
-  if world_result.exit_code != 0:
-    failed.add "world_tests"
-
-  echo "\n=== Running MCP tests ===\n"
-  let mcp_result = gorge_ex("nim mcp_tests")
-  echo mcp_result.output
-  if mcp_result.exit_code != 0:
-    failed.add "mcp_tests"
-
+  for name in names:
+    echo &"\n=== Running {name} ===\n"
+    let r = gorge_ex("nim " & name)
+    echo r.output
+    if r.exit_code != 0:
+      failed.add name
   echo "\n=== Test Summary ===\n"
   if failed.len > 0:
     echo "FAILED: " & failed.join(", ")
     quit 1
-  else:
-    echo "All tests passed!"
+  echo "All tests passed!"
+
+task test, "fast default tests (unit + vm); run test_all for the full suite":
+  run_tests ["test_unit", "test_vm"]
+
+task test_all, "full test suite (unit + vm + world + mcp)":
+  run_tests ["test_unit", "test_vm", "test_world", "test_mcp"]
 
 proc find_and_copy_dlls(dep_path, dest: string, dlls: varargs[string]) =
   for dep in dlls:

--- a/tasks.nim
+++ b/tasks.nim
@@ -353,10 +353,13 @@ task mcp_repro,
   if fail_count > 0:
     quit 1
 
+task mcp_tests, "run MCP integration tests (launches a private Enu)":
+  # The test self-launches a minimized Enu on a free port and tears it down, so
+  # no manually-running Enu is needed. Assumes the app is built, as `nim test`
+  # does for the world tests.
+  exec "nim c -r tests/mcp/enu_mcp_test.nim"
+
 task test, "run all tests":
-  # TODO: fold the MCP integration tests (tests/mcp/) into `nim test` once the
-  # MCP server can launch a private Enu instance on a free port. Until then they
-  # need a manually-running Enu — run them with `nim mcp_repro`.
   var failed: seq[string]
 
   echo "\n=== Running unit tests ===\n"
@@ -376,6 +379,12 @@ task test, "run all tests":
   echo world_result.output
   if world_result.exit_code != 0:
     failed.add "world_tests"
+
+  echo "\n=== Running MCP tests ===\n"
+  let mcp_result = gorge_ex("nim mcp_tests")
+  echo mcp_result.output
+  if mcp_result.exit_code != 0:
+    failed.add "mcp_tests"
 
   echo "\n=== Test Summary ===\n"
   if failed.len > 0:
@@ -572,7 +581,7 @@ task dist_package, "Build distribution binaries":
     # MCP server — resolves to <root>/bin/enu.exe (lib_dir.parent/bin); the
     # bin/ subdir avoids colliding with the enu.exe launcher at the root.
     mk_dir root & "/bin"
-    build_mcp("", root & "/bin/enu.exe")
+    build_mcp("-d:dist", root & "/bin/enu.exe")
     with_dir "dist":
       exec &"zip -r enu-{git_version}-windows-x64.zip enu-{git_version}"
   elif host_os == "macosx":
@@ -618,11 +627,11 @@ task dist_package, "Build distribution binaries":
     # MCP server, universal — resolves to <Resources>/bin/enu (lib_dir.parent/bin).
     mk_dir "dist/Enu.app/Contents/Resources/bin"
     build_mcp(
-      "--cpu:amd64 -l:'-target x86_64-apple-macos11' -t:'-target x86_64-apple-macos11'",
+      "-d:dist --cpu:amd64 -l:'-target x86_64-apple-macos11' -t:'-target x86_64-apple-macos11'",
       "dist/mcp.x86_64",
     )
     build_mcp(
-      "--cpu:arm64 -l:'-target arm64-apple-macos11' -t:'-target arm64-apple-macos11'",
+      "-d:dist --cpu:arm64 -l:'-target arm64-apple-macos11' -t:'-target arm64-apple-macos11'",
       "dist/mcp.arm64",
     )
     exec "lipo -create dist/mcp.x86_64 dist/mcp.arm64 -output dist/Enu.app/Contents/Resources/bin/enu"
@@ -667,7 +676,7 @@ task dist_package, "Build distribution binaries":
     copy_vmlib "vmlib", root & "/lib/vmlib"
     # MCP server — resolves to <root>/lib/bin/enu (lib_dir.parent/bin).
     mk_dir root & "/lib/bin"
-    build_mcp("", root & "/lib/bin/enu")
+    build_mcp("-d:dist", root & "/lib/bin/enu")
     exec "chmod +x " & root & "/lib/bin/enu"
     exec "chmod +x " & root & "/bin/enu"
     exec &"{gen()} write_export_presets --enu_version {git_version}"

--- a/tests/mcp/enu_mcp_test.nim
+++ b/tests/mcp/enu_mcp_test.nim
@@ -460,8 +460,12 @@ proc run_integration_tests() =
     echo "(50 tool calls) "
 
 proc run_hang_repro() =
+  # Regression repro for a past eval+screenshot hang. 25 iterations by default —
+  # enough to catch a regression cheaply; set MCP_HANG_ITERATIONS to stress it
+  # harder (or use `nim mcp_repro`, which loops the whole suite).
+  let iterations = parse_int(get_env("MCP_HANG_ITERATIONS", "25"))
   echo ""
-  echo "Hang repro (loops until hang or 500 calls):"
+  echo "Hang repro (loops until hang or " & $iterations & " calls):"
   echo "  eval+screenshot loop..."
   stdout.flush_file()
 
@@ -471,7 +475,7 @@ proc run_hang_repro() =
   discard s.do_initialize()
 
   var call = 0
-  while call < 500:
+  while call < iterations:
     inc call
     let ev =
       s.do_call_tool("eval", %*{"code": $call}, timeout_ms = 35000).tool_text
@@ -492,7 +496,7 @@ proc run_hang_repro() =
     stdout.flush_file()
 
   echo ""
-  echo "  PASS (500 calls without hang)"
+  echo "  PASS (" & $iterations & " calls without hang)"
 
 # ---- Main -----------------------------------------------------------------
 

--- a/tests/mcp/enu_mcp_test.nim
+++ b/tests/mcp/enu_mcp_test.nim
@@ -12,6 +12,7 @@
 
 import std/[osproc, streams, json, strutils, os, times, md5]
 import enu_mcp_reconnect_test
+import client
 
 type McpSession = object
   process: Process
@@ -495,22 +496,37 @@ proc run_hang_repro() =
 
 # ---- Main -----------------------------------------------------------------
 
-let is_integration =
-  get_env("ENU_CONNECT_ADDRESS", "") != "" or
-  get_env("ENU_LISTEN_ADDRESS", "") != ""
-
 echo "=== enu_mcp test suite ==="
 echo ""
 
 run_protocol_tests()
 
-if is_integration:
+# The integration tests need an Enu to talk to. If the caller points us at one
+# (ENU_CONNECT_ADDRESS / ENU_LISTEN_ADDRESS) we use it; otherwise we launch a
+# private, minimized instance on a free port and tear it down afterward — which
+# is what lets the suite run unattended under `nim test`.
+let external =
+  get_env("ENU_CONNECT_ADDRESS", "") != "" or
+  get_env("ENU_LISTEN_ADDRESS", "") != ""
+var managed = false
+if not external:
+  const repo = current_source_path().parent_dir.parent_dir.parent_dir
+  let address = Enu.launch(
+    repo / "vmlib" / "worlds" / "tutorial" / "tutorial-1", id = "enu_mcp_test"
+  )
+  put_env("ENU_CONNECT_ADDRESS", address)
+  managed = true
+
+if external or managed:
   run_integration_tests()
   run_reconnect_tests()
   run_hang_repro()
 else:
   echo ""
-  echo "(skipping integration tests — run with ENU_LISTEN_ADDRESS=127.0.0.1)"
+  echo "(skipping integration tests — set ENU_CONNECT_ADDRESS or launch one)"
+
+if managed:
+  Enu.kill()
 
 echo ""
 echo "=== All tests passed ==="


### PR DESCRIPTION
Builds on the merged MCP work so an agent (or a test) can stand up its own private Enu rather than relying on one the user is running, and splits the test suite into a fast default and a full run.

## Managed Enu instances
- **`launch_enu(level_dir, port=0)`** / **`kill_enu`** MCP tools. `launch_enu` requires a level, picks a free port by default, spawns a **minimized** Enu, connects, and returns the address; `kill_enu` terminates *our* process and disconnects. The server also kills its managed instance on exit, so nothing is orphaned.
- `Enu.launch`/`kill`/`disconnect` + a duplicated `free_port` live in the client layer. The launch target is resolved **statically per `defined(dist)` + OS** (dev uses the in-tree Godot binary via the compile-time repo path; dist uses the bundled executable) with an `ENU_EXE` override. The process is launched via `sh -c exec … > log` so the child PID is Enu itself (directly killable) and its output stays off the JSON-RPC stdout. `-d:dist` is now passed to the dist `build_mcp` calls.
- New **`--minimized`** launch flag (set_window_minimized + skip fullscreen); `world_tests` runs minimized too.

## Tests
- The MCP integration test now **self-launches** a private Enu on a free port (unless `ENU_CONNECT_ADDRESS`/`ENU_LISTEN_ADDRESS` points at one) and tears it down — so it runs unattended. The hang repro defaults to 25 iterations (`MCP_HANG_ITERATIONS` to stress it).
- **Fast/full split:** `nim test` now runs only the fast no-Godot tests (`test_unit` + `test_vm`, ~50s cold) for inner-loop validation; **`nim test_all`** runs the full suite (adds `test_world` + `test_mcp`, ~5min). Tasks renamed to a `test_` prefix; CI and CLAUDE.md updated.

## Caveats / follow-ups
- Windows managed launch raises (no `/bin/sh`); posix only for now.
- The Linux dist game-exe layout is a best guess; the dist macOS launch path is untestable without a dist build.
- `free_port` is duplicated from ed's test util — to be moved into ed later.