### PR TITLE
Platform riding, bot floor-follow (fall/climb), and explicit adopt/release

### DIFF
--- a/atlas.lock
+++ b/atlas.lock
@@ -15,7 +15,7 @@
     "ed.getenu.github.com": {
       "dir": "$deps/ed",
       "url": "https://github.com/getenu/ed",
-      "commit": "23fe53f159e4cb0af301cab98cafacc2a73c89ad",
+      "commit": "7b564cf1c1e07d732b7ce149154ba467c8155dae",
       "version": ""
     },
     "nanoid.nim.getenu.github.com": {
@@ -33,7 +33,7 @@
     "cligen": {
       "dir": "$deps/cligen",
       "url": "https://github.com/c-blake/cligen",
-      "commit": "ab8c6b4fe3cbe36466db41a3aee6e5cb32fa7864",
+      "commit": "f082560a4bbd4afa1b35e9810b291d17c265b666",
       "version": ""
     },
     "chroma": {
@@ -63,7 +63,7 @@
     "nimibook": {
       "dir": "$deps/nimibook",
       "url": "https://github.com/pietroppeter/nimibook",
-      "commit": "b02b02f3ddce3c5f765b1ef274115a689c6ecf9f",
+      "commit": "1405553199b12915a502df8b871ffe86dcfc5e91",
       "version": ""
     },
     "metrics": {
@@ -75,13 +75,13 @@
     "zippy": {
       "dir": "$deps/zippy",
       "url": "https://github.com/guzba/zippy",
-      "commit": "bcb8c1e1be6abb0a0e35a3c6040cdd9391cc993f",
+      "commit": "a0057dcc689bae60adfc286b8e49dc10db4c98d3",
       "version": ""
     },
     "unittest2": {
       "dir": "$deps/unittest2",
       "url": "https://github.com/status-im/nim-unittest2",
-      "commit": "92e1c13dcfb6d7e4ea6fb624fe9cc31e3dc76813",
+      "commit": "1efa65bb037185f0983ac4fa65932e8d3450825d",
       "version": ""
     },
     "nph.getenu.github.com": {
@@ -111,7 +111,7 @@
     "nim-libbacktrace.dsrw.github.com": {
       "dir": "$deps/nim-libbacktrace",
       "url": "https://github.com/dsrw/nim-libbacktrace",
-      "commit": "d8bd4ce5c46bb6d2f984f6b3f3d7380897d95ecb",
+      "commit": "99bc2ba16bc2d44f9a97e706304f64744d913d7f",
       "version": ""
     },
     "threading": {
@@ -123,7 +123,7 @@
     "flatty": {
       "dir": "$deps/flatty",
       "url": "https://github.com/treeform/flatty",
-      "commit": "c7091b096bcf275f47b666ef74bce73eda187ee3",
+      "commit": "07f6ba8ab96238e5bd1264cf0cea1d1746abb00c",
       "version": ""
     },
     "netty": {
@@ -135,19 +135,19 @@
     "supersnappy": {
       "dir": "$deps/supersnappy",
       "url": "https://github.com/guzba/supersnappy",
-      "commit": "4fed6553d539cbbfb17ab5fea16a58b4f1916e7d",
+      "commit": "e4df8cb5468dd96fc5a4764028e20c8a3942f16a",
       "version": ""
     },
     "faststreams": {
       "dir": "$deps/faststreams",
       "url": "https://github.com/status-im/nim-faststreams",
-      "commit": "50889cd16ec8771106cdd0eeea460039e8571e06",
+      "commit": "ce27581a3e881f782f482cb66dc5b07a02bd615e",
       "version": ""
     },
     "serialization": {
       "dir": "$deps/serialization",
       "url": "https://github.com/status-im/nim-serialization",
-      "commit": "4092500cea76154576539371709ae801afbd2a9d",
+      "commit": "b0f2fa32960ea532a184394b0f27be37bd80248b",
       "version": ""
     },
     "json_serialization": {
@@ -159,13 +159,13 @@
     "testutils": {
       "dir": "$deps/testutils",
       "url": "https://github.com/status-im/nim-testutils",
-      "commit": "6ce5e5e2301ccbc04b09d27ff78741ff4d352b4d",
+      "commit": "e4d37dc1652d5c63afb89907efb5a5e812261797",
       "version": ""
     },
     "nimib": {
       "dir": "$deps/nimib",
       "url": "https://github.com/pietroppeter/nimib",
-      "commit": "99ac3477f6a9d421ea65aeda1c9682d343c5bc35",
+      "commit": "54541820232ee41cfa719fac002c718f5e7d628d",
       "version": ""
     },
     "jsony": {
@@ -177,7 +177,7 @@
     "chronos": {
       "dir": "$deps/chronos",
       "url": "https://github.com/status-im/nim-chronos",
-      "commit": "45f43a9ad8bd8bcf5903b42f365c1c879bd54240",
+      "commit": "0646c444fce7c7ed08ef6f2c9a7abfd172ffe655",
       "version": ""
     },
     "results": {
@@ -189,7 +189,7 @@
     "stew": {
       "dir": "$deps/stew",
       "url": "https://github.com/status-im/nim-stew",
-      "commit": "4382b18f04b3c43c8409bfcd6b62063773b2bbaa",
+      "commit": "b66168735d6f3841c5239c3169d3fe5fe98b1257",
       "version": ""
     },
     "glob": {
@@ -219,19 +219,25 @@
     "webby": {
       "dir": "$deps/webby",
       "url": "https://github.com/treeform/webby",
-      "commit": "325d6ade0970562bee7d7d53961a2c3287f0c4bc",
+      "commit": "d7cdc16af7d0f03823d6e055af59743cde39b888",
       "version": ""
     },
     "crunchy": {
       "dir": "$deps/crunchy",
       "url": "https://github.com/guzba/crunchy",
-      "commit": "98eb6526982bb8aae8eec6e8781f4539fa19e049",
+      "commit": "180aecaa0774f65dba3fce9b33e6b00f4e77701e",
       "version": ""
     },
     "fusion": {
       "dir": "$deps/fusion",
       "url": "https://github.com/nim-lang/fusion",
       "commit": "0b0a0273b8df860cd54e3fcca7bb4c617244ac77",
+      "version": ""
+    },
+    "mustache": {
+      "dir": "$deps/mustache",
+      "url": "https://github.com/soasme/nim-mustache",
+      "commit": "1677949a848fc126a0716a67bba2c6217205255c",
       "version": ""
     },
     "parsetoml": {
@@ -243,19 +249,19 @@
     "bearssl": {
       "dir": "$deps/bearssl",
       "url": "https://github.com/status-im/nim-bearssl",
-      "commit": "25197fec8a3988d1153be7a1a79890b70e69d6db",
+      "commit": "11e798b62b8e6beabe958e048e9e24c7e0f9ee63",
       "version": ""
     },
     "httputils": {
       "dir": "$deps/httputils",
       "url": "https://github.com/status-im/nim-http-utils",
-      "commit": "f142cb2e8bd812dd002a6493b6082827bb248592",
+      "commit": "c53852d9e24205b6363bba517fa8ee7bde823691",
       "version": ""
     },
     "nimsimd": {
       "dir": "$deps/nimsimd",
       "url": "https://github.com/guzba/nimsimd",
-      "commit": "3f6b2668ffb0867d0bf786a658b817763e611350",
+      "commit": "9436cb4dda40ff2e96f1ce229e6733ef4524879e",
       "version": ""
     }
   },
@@ -301,6 +307,7 @@
     "--path:\"deps/glob/src\"",
     "--path:\"deps/toml_serialization\"",
     "--path:\"deps/fusion/src\"",
+    "--path:\"deps/mustache/src\"",
     "--path:\"deps/parsetoml/src\"",
     "--path:\"deps/bearssl\"",
     "--path:\"deps/httputils\"",
@@ -321,7 +328,7 @@
       "",
       "requires \"https://github.com/getenu/Nim#bea4c144\",",
       "  \"https://github.com/getenu/godot-nim 0.8.6\",",
-      "  \"https://github.com/getenu/ed 0.30.2\",",
+      "  \"https://github.com/getenu/ed 0.30.3\",",
       "  \"https://github.com/getenu/nanoid.nim >= 0.2.1\",",
       "  \"https://github.com/treeform/pretty >= 0.2.0\", \"cligen\", \"chroma\", \"markdown\",",
       "  \"chronicles\", \"dotenv\", \"nimibook\", \"metrics#a1296ca\", \"zippy\", \"unittest2\",",

--- a/docs/notes/adopt-destructor-teardown.md
+++ b/docs/notes/adopt-destructor-teardown.md
@@ -1,0 +1,231 @@
+# Adopt / reparent + destructor-driven node teardown
+
+Design spec + status for letting a unit ride a moving platform (bot-ferry,
+rider-carry). Written after a deep investigation pass; supersedes the (wrong)
+"adopt = move between `.units` collections, no new plumbing" note in the old
+session handoff.
+
+## TL;DR
+
+- **Done & committed** (`adopt-lifecycle`, on top of `course`): `node.model`
+  is now a `{.cursor.}` on the four Unit-bearing nodes — breaks the
+  `unit.node` ⇄ `node.model` reference cycle so a unit that leaves all owning
+  collections can be reclaimed by ORC. Build + fast tests green; world tests
+  4/5 (one pre-existing voxel-teardown flake, see below).
+- **Implemented** (`adopt-lifecycle`): `me.adopt(unit)` / `unit.release` via the
+  `TRANSFERRING` flag (see "Decided approach"). Builds; fast tests green; all new
+  behavior is gated on `TRANSFERRING`, so non-adopt paths are unchanged.
+  **In-world ride not yet validated** — blocked on the `test_world` isolation
+  fix (see "Test prerequisite").
+  - Guard sites: `node_controllers.nim` — `set_global` skips its origin shift
+    while transferring; `add_or_defer` early-returns for a unit that already has
+    a node (relink); the three removed-watchers skip `remove_from_scene`; the
+    `state.units` added-path clears a stale `parent` (for `release`).
+    `worker.nim` `for_all_units` skips re-join (added) and skips
+    destroy/unmap/file-removal (removed). `host_bridge.nim` `adopt`/`release`;
+    declared in `share/vmlib/enu/base_bridge.nim`.
+
+## Decided approach (interim — agreed)
+
+Ship `adopt` now behind a transient flag; do the clean destructor-driven
+teardown as a follow-up. Tracking issues:
+- **getenu/enu#65** — destructor-driven model + node cleanup (the real fix; will
+  let us delete the flag).
+- **getenu/ed#26** — `set_owner` transfer / single-owner invariant (for the
+  eventual membership/ownership split).
+
+Interim plan:
+1. **Ownership moves with membership, for now.** `adopt` removes the unit from
+   its current units collection and adds it to the new parent's `.units`
+   (`OWNS_MEMBERS`), so the platform owns the rider until #65/#26 land. The
+   membership-vs-ownership split (riders not owned by the platform; re-home a
+   non-owned member on parent destroy) is deferred.
+2. **`TRANSFERRING` flag** routes the watchers: `adopt` sets it, does the
+   collection remove/add, clears it. The node_controller removed-watcher and the
+   worker's reap path **skip destroying a `TRANSFERRING` unit** — so a move
+   detaches/re-attaches the node instead of tearing it down. Not blanket `pause`;
+   an explicit, intent-named signal that the destructor work later removes.
+   - **Flag scope:** the membership move syncs remotely (`.units` is
+     `SYNC_REMOTE`), and every context that applies it runs the same
+     removed→destroy path — so the flag must reach them all. Make it a
+     **`GlobalModelFlags`** (`SYNC_LOCAL + SYNC_REMOTE`), not a `local_flags`
+     entry (`SYNC_LOCAL` only reaches worker↔main — fine single-process, a
+     latent MP bug). `TRANSFERRING` is a transient *fact about the unit*, not
+     per-view state, so global is also the right semantic home.
+
+## Why the original plan was wrong
+
+The old handoff said: "adopt = move the unit between `.units` collections; the
+node controller reparents the node; no new bridge plumbing needed."
+
+1. **Collection-removal == destroy, today.** `units` is `OWNS_MEMBERS`
+   (`models/units.nim:46`). The node controller's `watch_units`/`state.units`
+   `removed` branches call `remove_from_scene` → `unit.destroy`
+   (`controllers/node_controllers.nim:153,193,43`). So moving a unit by
+   collection membership *destroys* it.
+2. **`set_global` doesn't move to an arbitrary parent.** It only swaps the
+   node between `state.nodes.data` (root) and `unit.parent.node`
+   (`node_controllers.nim:105-117`), reading whatever `unit.parent` already is.
+   `GLOBAL` is just "node at root vs under my existing parent" — not a mover.
+   Its only relevance to adopt: an adopted unit must end up **non-GLOBAL** so
+   its node nests under the platform and Godot composes the transform.
+3. **`set_global`'s transform shift is the wrong offset** for adoption — it
+   uses `unit.start_transform.origin` (the child's spawn offset), correct only
+   for a unit instanced *at* its parent. An adoptee needs the **parent's**
+   current world origin.
+
+## The corrected model (verified against ed + enu)
+
+- **ed already does "remove = unlink, not free."** `type_registry.nim:270`:
+  *"REMOVE only unlinks — it never frees... This is what gives move-identity
+  for free: a removed-then-readded replica re-links the same instance."* A body
+  is freed by ORC when its last real reference drops; `RefHandle.=destroy`
+  (`ed/types.nim:724`) then prunes `ref_pool`. **enu's eager destroy-on-remove
+  is a node-controller policy layered on top of ed, and it's out of step with
+  ed's own model.**
+- **`owned_by`** (`ed/types.nim:408`, public) is the authoritative, *synced*
+  move-vs-delete signal: on ADD to an `OWNS_MEMBERS` collection,
+  `owned_by[owner].incl(id)`; on REMOVE, `excl` (`type_registry.nim:285-300`).
+  Re-derived identically on every context from the synced ADD/REMOVE, so the
+  **main thread** sees it without extra plumbing.
+- **`EdRef.destroy()`** (`ed/zens/operations.nim:477`) is *not* redundant with
+  ORC: it `lifetime.finish()`s, then `destroy_owned(self.id)` which broadcasts
+  DESTROY so replicas tear down their mirrors **and** tears down the standalone
+  `Shared` voxel tables attributed via `id.own:`. So on a **true delete**
+  `unit.destroy` must run; on a **move** it must not.
+- **Cross-thread (the key constraint).** Two ed contexts: `main`
+  (`game.nim:206`) and `worker` (`worker.nim:412`); worker subscribes to main
+  (`worker.nim:426`). The "same" unit is **two objects**, one per thread,
+  synced by serialized channel messages. **Only the main-thread unit carries
+  `.node`** (set in `add_to_scene`, main thread). `state`, `current_build`,
+  `previous_build` are `{.threadvar.}` — so a main-thread `=destroy` touches
+  only main-thread state, and `queue_free` is legal there.
+  - Consequence: **`host_bridge` runs on the worker thread, where `unit.node`
+    is nil.** `adopt` can only do *ed* ops on the worker; the **main thread**
+    must do the node reparent in reaction to the synced ed changes — exactly
+    how `set_global` already works (worker toggles `GLOBAL` → syncs → main's
+    `global_flags.watch` → `set_global` reparents). The move-detection signal
+    must therefore be **synced state (`owned_by`)**, never a worker-local flag.
+
+## Design for `adopt` / `release`
+
+### Worker side (`controllers/script_controllers/host_bridge.nim`, new procs)
+
+`adopt(platform, unit)` — pure ed ops, add-first so the unit is re-owned
+before the old removal fires:
+
+```
+let old_owner = if ?unit.parent: unit.parent.units else: state.units
+platform.units.add unit          # owned_by[platform.id].incl(unit.id)
+old_owner -= unit                # owned_by[old].excl; unit stays alive (re-owned)
+unit.global_flags -= GLOBAL      # drives the node reparent on the main thread
+unit.transform_value.origin =    # world -> platform-local (origin-only)
+  unit.transform.origin - platform.transform.origin
+```
+
+`release(unit)` — mirror: `state.units.add unit; platform.units -= unit;
+unit.global_flags += GLOBAL; origin += platform.transform.origin`. (`platform`
+= `unit.parent` at call time.)
+
+Expose via `share/vmlib/enu/base_bridge.nim` (`bridged_to_host`): `proc
+adopt*(self: Unit, unit: Unit)` and `proc release*(self: Unit)`. Note today's
+VM API has no way to reach another unit's `.units`/`parent` — adopt/release are
+the bridged ops that do it.
+
+### Main side (`controllers/node_controllers.nim`) — two additive guards
+
+The node reparent itself is already handled by `set_global` firing from the
+synced `GLOBAL`-removed change (it reparents the node to `unit.parent.node`,
+which `fix_parents` has set to the platform). We only need to stop the *other*
+two watchers from rebuilding/destroying the node for a relink:
+
+1. **`add_or_defer` / added watch**: `if ?unit.node: return` — the unit already
+   has a node (it's a relink, not a fresh spawn); the reparent comes via
+   `set_global`. (Fresh units always have `node == nil` here, so normal spawns
+   are unaffected.)
+2. **`removed` branches** (`watch_units` + `state.units`): skip
+   `remove_from_scene` when the unit is **owned elsewhere** —
+   `unit.id in ctx.owned_by.getOrDefault(<other owner>)`. Normal deletes
+   (`clear_all`, `delete`, `claim_name`, reload) are never owned elsewhere, so
+   they take the exact current path. **This is the safety property: the new
+   branch only triggers mid-move.**
+
+A helper like `proc relinked(ctx: EdContext, unit: Unit, from_owner_id: string):
+bool` that scans `owned_by` for `unit.id` under any owner ≠ `from_owner_id`.
+
+### Transform / `set_global` cleanup
+
+`set_global`'s origin shift uses `start_transform.origin` (wrong for an
+arbitrary adoptee). Two options: (a) let `set_global` run its (wrong) shift and
+let the synced `transform_value` change from the worker overwrite it — final
+state correct, possible 1-frame flicker; (b) cleaner: teach `set_global` to use
+`unit.parent.transform.origin` as the offset when the parent isn't the root.
+Prefer (b) once it's the adopt path; verify it doesn't regress the existing
+instanced-child GLOBAL toggle.
+
+### Rotation caveat
+
+`global_from`/`local_to` (`core.nim:233/240`) are **origin-only**. A
+*translating* platform (ferry, elevator) is fine. A *rotating* platform won't
+rotate the rider — that needs full-basis composition in the conversion.
+
+## The destructor-driven endgame (the "right" version)
+
+The guards above are surgical but still leave enu's "remove = destroy" policy in
+place for the non-move path. The clean end-state, which the cursor commit is the
+first step toward:
+
+- Add a **main-thread `Unit`/`Model` `=destroy`** that frees `self.node`
+  (`node.model = nil; node.queue_free()`), safe because the node-bearing unit
+  is main-thread-local (see cross-thread note). Mirror ed's deferred pattern
+  only if profiling shows reclaim happening off the main thread (it shouldn't).
+- Make the `removed` watcher **never** free the node — removal just drops
+  ownership; the node dies with the unit (ORC) via `=destroy`.
+- `unit.destroy` (the ed teardown/sync) still runs explicitly on true deletes
+  (`clear_all`/`delete`/`claim_name`/reload) — those call sites already do, or
+  can, call it directly. This is the load-bearing part to get right: every
+  current path that relies on `removed → remove_from_scene → unit.destroy` must
+  instead call `unit.destroy` itself (which then frees owned containers + syncs
+  DESTROY; the node follows via ORC). Needs careful in-world validation of
+  level reload, single delete, and multiplayer mirror teardown.
+
+This removes move-detection entirely (a move never destroys because the unit is
+never reclaimed), at the cost of auditing every teardown call site. Bigger, but
+no special cases.
+
+## Test prerequisite (do this first)
+
+**`test_world` corrupts tracked sources on this branch.** Running it
+deletes/rewrites files under `tests/worlds/` because PR #62's `--temp-workdir`
+isolation fix isn't on `course`/`adopt-lifecycle` yet. Before any in-world adopt
+work, either land/rebase onto PR #62 or cherry-pick the `--temp-workdir` commit.
+(Recover from an accidental run with `git checkout -- tests/worlds/`.)
+
+## Test plan for adopt (once unblocked)
+
+Headless, per the handoff's MCP driving, against a **/tmp scratch level** (never
+a tracked world):
+
+1. Spawn a platform build that moves (`forever:` translate), and a bot at root.
+2. `me.adopt(bot)` from the platform script (or `bot`-targeted).
+3. Poll the bot's **world** position across frames → it tracks the platform
+   (bot-ferry: bots don't auto-ride, so this is the real win).
+4. `bot.release` → bot re-roots to `state.units`, stops riding, doesn't jump.
+5. Assert neither adopt nor release teleports the bot (transform conversion).
+6. Re-run `test_unit`/`test_vm` + (on an isolated tree) `test_world` x3 to
+   confirm normal spawn/teardown is unregressed by the two guards.
+
+## Risks / watch-items
+
+- **Synced-change ordering** on the main thread: membership ADD/REMOVE, the
+  `GLOBAL` flag change, and the `transform_value` change arrive as separate
+  synced ops; the reparent (set_global) and transform must converge regardless
+  of order. Validate with the platform already moving.
+- **The voxel-teardown flake**: bulk-spawn `test_world` failed 1/5 with
+  `VoxelMemoryPool: 4294967294 blocks still used` (an over-decrement) then
+  passed 4/4. Pre-existing (baseline shows the same class of at-exit leak
+  noise); not caused by the cursor change, but worth a separate look since a
+  voxel double-free could interact with lifecycle changes.
+- **`release` requires re-rooting** an adopted unit (`platform.units` →
+  `state.units`) — make sure the root `state.units` add path (ownerless
+  collection) sets up `parent = nil` and GLOBAL correctly.

--- a/enu.nimble
+++ b/enu.nimble
@@ -8,7 +8,7 @@ src_dir = "src"
 
 requires "https://github.com/getenu/Nim#bea4c144",
   "https://github.com/getenu/godot-nim 0.8.6",
-  "https://github.com/getenu/ed 0.30.2",
+  "https://github.com/getenu/ed 0.30.3",
   "https://github.com/getenu/nanoid.nim >= 0.2.1",
   "https://github.com/treeform/pretty >= 0.2.0", "cligen", "chroma", "markdown",
   "chronicles", "dotenv", "nimibook", "metrics#a1296ca", "zippy", "unittest2",

--- a/share/vmlib/enu/base_bridge.nim
+++ b/share/vmlib/enu/base_bridge.nim
@@ -45,6 +45,8 @@ bridged_to_host:
   proc lock*(self: Unit): bool
   proc `lock=`*(self: Unit, value: bool)
   proc reset*(self: Unit, clear = false)
+  proc adopt*(self: Unit, unit: Unit)
+  proc release*(self: Unit)
   proc press_action*(name: string)
   proc release_action*(name: string)
   proc load_level*(level: string, world = "")

--- a/src/controllers/node_controllers.nim
+++ b/src/controllers/node_controllers.nim
@@ -105,16 +105,23 @@ proc add_to_scene(unit: Unit) =
 proc set_global(unit: Unit, global: bool) =
   var parent_node = unit.node.get_node("..")
   parent_node.remove_child(unit.node)
+  # During a transfer (adopt/release) the node reparents here, but `adopt`
+  # sets the unit's parent-local transform explicitly, so skip the
+  # start_transform-based origin shift (it's the wrong offset for an arbitrary
+  # adoptee — it assumes the unit was instanced at its parent).
+  let transferring = TRANSFERRING in unit.global_flags
   if global:
     state.nodes.data.add_child(unit.node)
     unit.node.owner = state.nodes.data
-    unit.transform_value.origin =
-      unit.transform.origin + unit.start_transform.origin
+    if not transferring:
+      unit.transform_value.origin =
+        unit.transform.origin + unit.start_transform.origin
   else:
     unit.parent.node.add_child(unit.node)
     unit.node.owner = unit.parent.node
-    unit.transform_value.origin =
-      unit.transform.origin - unit.start_transform.origin
+    if not transferring:
+      unit.transform_value.origin =
+        unit.transform.origin - unit.start_transform.origin
 
 proc reset_nodes() =
   current_build = nil
@@ -131,8 +138,9 @@ proc find_nested_changes(parent: Change[Unit]) =
         change.item.fix_parents(parent.item)
         change.item.add_to_scene()
       elif Removed in change.changes:
-        reset_nodes()
-        change.item.remove_from_scene()
+        if TRANSFERRING notin change.item.global_flags:
+          reset_nodes()
+          change.item.remove_from_scene()
     elif change.type_name == $Change[GlobalModelFlags]:
       let change = Change[GlobalModelFlags](change)
       if change.item == GLOBAL:
@@ -149,8 +157,9 @@ proc watch_units(self: NodeController, unit: Unit) {.gcsafe.} =
       change.item.fix_parents(unit)
       self.add_or_defer(change.item)
     elif removed:
-      reset_nodes()
-      change.item.remove_from_scene()
+      if TRANSFERRING notin change.item.global_flags:
+        reset_nodes()
+        change.item.remove_from_scene()
 
   unit.global_flags.watch(unit):
     if GLOBAL.added:
@@ -163,6 +172,11 @@ proc add_or_defer(self: NodeController, unit: Unit) {.gcsafe.} =
   ## containers). Defer the scene add until the core containers fill — the
   ## worker's deep fetch brings them, and `drain_pending` (per frame) finishes
   ## the join. Field watchers self-heal the rest via Fill changes.
+  if ?unit.node:
+    # Relink: the unit already has a node (it's moving between collections, not
+    # being freshly spawned). Don't re-instance or re-watch — the live node is
+    # reparented by `set_global` when the synced GLOBAL change lands.
+    return
   if unit.sync_ready:
     unit.add_to_scene()
     self.watch_units(unit)
@@ -188,9 +202,15 @@ proc watch*(self: NodeController, state: GameState) =
   state.units.changes:
     info "node_ctrl state.units change", added, removed, id = change.item.id
     if added:
+      # A direct member of root `state.units` is top-level (parentless). Clear a
+      # stale back-ref left by `release` (which re-roots an adopted unit).
+      change.item.parent = nil
       self.add_or_defer(change.item)
     elif removed:
-      change.item.remove_from_scene()
+      if TRANSFERRING in change.item.global_flags:
+        discard
+      else:
+        change.item.remove_from_scene()
       # No explicit queue_free: the Unit is an EdRef, reclaimed by ORC once
       # unreferenced (ed then prunes its ref_pool entry). remove_from_scene
       # already handles the Godot node teardown. (step 4.3)

--- a/src/controllers/script_controllers/host_bridge.nim
+++ b/src/controllers/script_controllers/host_bridge.nim
@@ -117,6 +117,7 @@ proc new_instance(self: Worker, src: Unit, dest: PNode) =
 
   var clone = src.clone(self.active_unit, id)
   assert not clone.is_nil
+  clone.spawned_by = self.active_unit.id
   clone.script_ctx = ScriptCtx.init(
     owner = clone, clone_of = src, interpreter = self.interpreter
   )
@@ -505,6 +506,16 @@ proc delete(self: Unit) =
   ## Remove the unit from the level and delete its on-disk script + data.
   ## Distinct from the `destroy` method, which only tears down the in-memory
   ## instance.
+
+  # Evacuate children we don't own so they outlive us: real units, the player,
+  # and instances spawned elsewhere (e.g. one adopted onto us to ride). Our own
+  # instances (`spawned_by == self.id`) stay and are torn down in the cascade
+  # when we're removed below. Done here, before removal, so it isn't re-entrant
+  # with the destroy cascade (which mutating ed mid-teardown would be).
+  for child in self.units.value:
+    if child.spawned_by != self.id:
+      child.reparent_to_root()
+
   if ?self.script_ctx and self.script_ctx.script != "" and
       file_exists(self.script_ctx.script):
     try:
@@ -521,6 +532,34 @@ proc delete(self: Unit) =
     state.units -= self
   else:
     self.parent.units -= self
+
+proc adopt(self: Unit, unit: Unit) =
+  ## Make `unit` ride `self` (e.g. a moving platform): move it from its current
+  ## units collection into `self.units` and nest its node under `self`'s, so the
+  ## engine composes transforms and `unit` follows `self`. Bots don't auto-ride a
+  ## moving platform — this is how you make them. Ownership moves with membership
+  ## for now (`self` owns `unit` until destructor-driven teardown lands — see
+  ## getenu/enu#65). `TRANSFERRING` keeps the remove/add from tearing the unit
+  ## down (it's a move, not a delete).
+  if unit == self or unit.parent == self:
+    return
+  unit.global_flags += TRANSFERRING
+  let old_owner = if ?unit.parent: unit.parent.units else: state.units
+  self.units.add unit
+  old_owner -= unit
+  unit.parent = self
+  unit.global_flags -= GLOBAL
+  # World -> parent-local origin. Origin-only is fine for a translating platform;
+  # a rotating one needs basis composition (see docs/notes/adopt-*). `self` is
+  # GLOBAL, so its node sits at the world root and its origin is the offset.
+  unit.transform_value.origin = unit.transform.origin - self.transform.origin
+  after_boop:
+    unit.global_flags -= TRANSFERRING
+
+proc release(self: Unit) =
+  ## Reverse of `adopt`: re-root `self` to the top-level units collection and
+  ## restore its world transform, so it stops riding its parent.
+  self.reparent_to_root()
 
 proc speed(self: Unit): float =
   types.speed(self)
@@ -1539,7 +1578,7 @@ proc bridge_to_vm*(worker: Worker) =
     reset_level, current_colliders, added_units, all_players, all_builds,
     all_bots, all_signs, all_units, signal_test_complete, now_seconds,
     dump_stats, find_voxel_overlaps, units_in_box, floor_at, clear_box, bounds,
-    overlaps, units_overlapping, box_is_free, bounds_at
+    overlaps, units_overlapping, box_is_free, bounds_at, adopt, release
 
   result.bridged_from_vm "base_bridge_private",
     action_running, `action_running=`, yield_script, begin_turn, begin_move,

--- a/src/controllers/script_controllers/host_bridge.nim
+++ b/src/controllers/script_controllers/host_bridge.nim
@@ -507,14 +507,27 @@ proc delete(self: Unit) =
   ## Distinct from the `destroy` method, which only tears down the in-memory
   ## instance.
 
-  # Evacuate children we don't own so they outlive us: real units, the player,
-  # and instances spawned elsewhere (e.g. one adopted onto us to ride). Our own
-  # instances (`spawned_by == self.id`) stay and are torn down in the cascade
-  # when we're removed below. Done here, before removal, so it isn't re-entrant
-  # with the destroy cascade (which mutating ed mid-teardown would be).
-  for child in self.units.value:
-    if child.spawned_by != self.id:
-      child.reparent_to_root()
+  # Evacuate descendants we don't own so they outlive us: real units, the
+  # player, and instances spawned elsewhere (e.g. one adopted onto us to ride).
+  # Our own instances (`spawned_by == self.id`) stay and are torn down in the
+  # cascade when we're removed below — but the cascade is recursive, so a
+  # foreign unit adopted onto one of our instances must be evacuated too: we
+  # recurse through our own instances and evacuate the top-most foreign unit of
+  # each branch (its own subtree rides along with it). Collected first
+  # (reparenting mutates the tree), and done here, before removal, so it isn't
+  # re-entrant with the destroy cascade (which mutating ed mid-teardown would
+  # be).
+  var foreign: seq[Unit]
+  proc collect(children: seq[Unit]) =
+    for child in children:
+      if child.spawned_by != self.id:
+        foreign.add child
+      else:
+        collect(child.units.value)
+
+  collect(self.units.value)
+  for unit in foreign:
+    unit.reparent_to_root()
 
   if ?self.script_ctx and self.script_ctx.script != "" and
       file_exists(self.script_ctx.script):
@@ -543,16 +556,35 @@ proc adopt(self: Unit, unit: Unit) =
   ## down (it's a move, not a delete).
   if unit == self or unit.parent == self:
     return
+  # Adopting an ancestor would make parent links circular — every parent walk
+  # (local_to, world_from, walk_tree) would then loop forever and hang the
+  # worker.
+  var ancestor = self.parent
+  while ?ancestor:
+    if ancestor == unit:
+      logger("err", "can't adopt " & unit.id & ": it contains " & self.id)
+      return
+    ancestor = ancestor.parent
+  # Only top-level units can be adopted for now: the node reparents off the
+  # GLOBAL flag's removed-edge, and a nested unit has no GLOBAL flag to remove —
+  # the model would move but the node would stay under the old parent. `release`
+  # first. (Proper chained adoption comes with destructor-driven teardown,
+  # getenu/enu#65.)
+  if ?unit.parent:
+    logger(
+      "err",
+      "can't adopt " & unit.id & ": it's already on " & unit.parent.id &
+        "; release it first",
+    )
+    return
   unit.global_flags += TRANSFERRING
-  let old_owner = if ?unit.parent: unit.parent.units else: state.units
   self.units.add unit
-  old_owner -= unit
+  state.units -= unit
   unit.parent = self
   unit.global_flags -= GLOBAL
-  # World -> parent-local origin. Origin-only is fine for a translating platform;
-  # a rotating one needs basis composition (see docs/notes/adopt-*). `self` is
-  # GLOBAL, so its node sits at the world root and its origin is the offset.
-  unit.transform_value.origin = unit.transform.origin - self.transform.origin
+  # World -> parent-local through the platform's full transform chain, so
+  # adopting onto an already-rotated platform lands at the right local spot.
+  unit.transform_value.origin = unit.transform.origin.local_into(self)
   after_boop:
     unit.global_flags -= TRANSFERRING
 

--- a/src/controllers/script_controllers/worker.nim
+++ b/src/controllers/script_controllers/worker.nim
@@ -382,14 +382,19 @@ proc watch_units(
           # fetch pulls its whole ownership closure (containers + subtree); the
           # fills relay to the node ctx, whose deferred scene add completes.
           discard Ed.thread_ctx.fetch(unit.id, deep = true)
-        unit.collisions.track proc(changes: seq[Change[(string, Vector3)]]) =
-          # script_ctx is nil for a unit that never finished joining (a narrow
-          # replica's deferred join, destroyed before its fetch completed — e.g.
-          # an agent bot churned during a reload). The CLOSED this watcher gets
-          # from that destroy must not deref it.
-          if ?unit.script_ctx:
-            unit.script_ctx.timer = get_mono_time()
-        self.watch_units(unit.units, unit, body)
+        # A TRANSFERRING add is a reparent relink (adopt/release), not a new
+        # unit: its collision and child-collection watchers are already
+        # registered, and re-adding them would run every downstream join and
+        # teardown once per accumulated subscription (growing with each hop).
+        if TRANSFERRING notin unit.global_flags:
+          unit.collisions.track proc(changes: seq[Change[(string, Vector3)]]) =
+            # script_ctx is nil for a unit that never finished joining (a narrow
+            # replica's deferred join, destroyed before its fetch completed —
+            # e.g. an agent bot churned during a reload). The CLOSED this
+            # watcher gets from that destroy must not deref it.
+            if ?unit.script_ctx:
+              unit.script_ctx.timer = get_mono_time()
+          self.watch_units(unit.units, unit, body)
 
 template for_all_units(self: Worker, body: untyped) {.dirty.} =
   self.watch_units state.units,

--- a/src/controllers/script_controllers/worker.nim
+++ b/src/controllers/script_controllers/worker.nim
@@ -238,10 +238,14 @@ proc update_files*(self: Worker) =
       except OSError:
         discard
 
-  # Build root-unit table once for JSON watch and orphan detection
-  var root_units: Table[string, Unit]
-  for unit in state.units.value:
-    root_units[unit.id] = unit
+  # Table of every loaded unit (whole tree, not just top level) for the JSON
+  # watch + orphan detection. A unit adopted onto another lives nested in memory
+  # but its data stays at the flat top-level path, so it'd otherwise look "new"
+  # to the walk_dirs scan below and get reconstructed. Walking the tree keeps it
+  # recognized as already-loaded.
+  var loaded_units: Table[string, Unit]
+  state.units.value.walk_tree proc(unit: Unit) {.gcsafe.} =
+    loaded_units[unit.id] = unit
 
   # JSON watch: reload changed units inline; collect newly-appeared ones to
   # load together as a batch afterward.
@@ -251,8 +255,8 @@ proc update_files*(self: Worker) =
     let json_file = dir / unit_id & ".json"
     if not file_exists(json_file):
       continue
-    if unit_id in root_units:
-      let unit = root_units[unit_id]
+    if unit_id in loaded_units:
+      let unit = loaded_units[unit_id]
       if not (unit of Build or unit of Bot) or not ?unit.script_ctx:
         continue
       if unit.script_ctx.last_saved_json_mtime == Time.default:
@@ -296,7 +300,7 @@ proc update_files*(self: Worker) =
     let stem = script_path.split_file.name
     if stem == "players":
       continue
-    if stem notin root_units:
+    if stem notin loaded_units:
       let json_file = state.config.data_dir / stem / stem & ".json"
       if not file_exists(json_file) and
           script_path notin self.orphan_scripts_reported:
@@ -453,7 +457,11 @@ proc worker_thread(params: (EdContext, GameState)) {.gcsafe.} =
 
   worker.for_all_units:
     if added:
-      if unit.sync_ready:
+      if TRANSFERRING in unit.global_flags:
+        # Relink (adopt/release): the unit is already joined and its script is
+        # running. Re-adding it to a new collection must not re-join or re-watch.
+        discard
+      elif unit.sync_ready:
         unit.worker_thread_joined(worker)
         worker.watch_code unit
       else:
@@ -462,17 +470,22 @@ proc worker_thread(params: (EdContext, GameState)) {.gcsafe.} =
         worker.pending_units.add unit
 
     if removed:
-      worker.unmap_unit(unit)
+      if TRANSFERRING in unit.global_flags:
+        # Moving between collections, not leaving the level: keep the unit, its
+        # script mapping, and its on-disk script/data intact.
+        discard
+      else:
+        worker.unmap_unit(unit)
 
-      if ?unit.script_ctx:
-        unit.script_ctx.running = false
-        unit.script_ctx.callback = nil
-        if not (unit of Player) and LOADING_SCRIPT notin state.local_flags and
-            not ?unit.clone_of:
-          remove_file unit.script_ctx.script
-          remove_dir unit.data_dir
+        if ?unit.script_ctx:
+          unit.script_ctx.running = false
+          unit.script_ctx.callback = nil
+          if not (unit of Player) and LOADING_SCRIPT notin state.local_flags and
+              not ?unit.clone_of:
+            remove_file unit.script_ctx.script
+            remove_dir unit.data_dir
 
-      unit.destroy
+        unit.destroy
 
   let player = state.player
 

--- a/src/core.nim
+++ b/src/core.nim
@@ -258,6 +258,13 @@ proc world_from*(self: Vector3, unit: Unit): Vector3 =
     result = unit.transform.xform_vector3(result)
     unit = unit.parent
 
+proc local_into*(self: Vector3, unit: Unit): Vector3 =
+  ## Inverse of `world_from`: world point -> `unit`-local through each
+  ## ancestor's full transform (root's inverse applied first, `unit`'s last).
+  if unit.is_nil:
+    return self
+  unit.transform.xform_inv_vector3(self.local_into(unit.parent))
+
 proc `+=`*(self: EdValue[string], str: string) =
   self.value = self.value & str
 

--- a/src/core.nim
+++ b/src/core.nim
@@ -246,6 +246,18 @@ proc local_to*(self: Vector3, unit: Unit): Vector3 =
     result -= unit.transform.origin
     unit = unit.parent
 
+proc world_from*(self: Vector3, unit: Unit): Vector3 =
+  ## Local point -> world through each ancestor's FULL transform, so it's
+  ## correct on rotated/scaled units. `global_from` above only sums origins,
+  ## which silently breaks once a unit has turned: a point on a rotated
+  ## platform maps to where it would be had the platform never rotated. The
+  ## exact inverse of the node's `to_local`.
+  result = self
+  var unit = unit
+  while unit != nil:
+    result = unit.transform.xform_vector3(result)
+    unit = unit.parent
+
 proc `+=`*(self: EdValue[string], str: string) =
   self.value = self.value & str
 

--- a/src/models/bots.nim
+++ b/src/models/bots.nim
@@ -27,7 +27,11 @@ method on_begin_move*(
     duration += delta
     if duration >= finish_time:
       self.velocity_value.touch(vec3())
-      self.transform_value.origin = finish.snapped(vec3(0.1, 0.1, 0.1))
+      var f = finish.snapped(vec3(0.1, 0.1, 0.1))
+      # Y is owned by the node-side floor-follow (gravity / step-up); don't reset
+      # it, or a bot that fell during the move would snap back up to cliff height.
+      f.y = self.transform.origin.y
+      self.transform_value.origin = f
       return DONE
     else:
       self.velocity_value.touch(moving * self.speed)

--- a/src/models/builds.nim
+++ b/src/models/builds.nim
@@ -223,7 +223,7 @@ proc log_block_placement(self: Build, local: Vector3, color: Colors) =
     unit_id: self.id,
     color: color,
     local_position: local,
-    global_position: local.global_from(self),
+    global_position: local.world_from(self),
     timestamp: get_mono_time(),
   )
   state.player.block_log_entries.add entry
@@ -250,7 +250,9 @@ proc remove(self: Build) =
         self.parent.units -= self
 
 proc fire(self: Build) =
-  let global_point = self.target_point.global_from(self)
+  # Full transform, not global_from: on a rotated platform the origin-only sum
+  # drops the rotation, so the dropped bot lands blocks from the aim target.
+  let global_point = self.target_point.world_from(self)
   if state.tool notin {DISABLED, Tools.NONE, CODE_MODE, PLACE_BOT}:
     state.skip_block_paint = true
     draw_normal = self.target_normal

--- a/src/models/units.nim
+++ b/src/models/units.nim
@@ -278,10 +278,11 @@ proc walk_tree*(root: Unit, callback: proc(unit: Unit) {.gcsafe.}) =
   walk_tree(@[root], callback)
 
 proc data_dir*(self: Unit): string =
-  if self.parent.is_nil:
-    state.config.data_dir / self.id
-  else:
-    self.parent.data_dir / self.id
+  ## Always top-level: a unit's on-disk data lives at `config.data_dir/<id>/`
+  ## regardless of in-memory nesting (adopt, instances). Reparenting a unit
+  ## never moves its files, and the file watcher finds every unit at a stable,
+  ## flat path — so an adopted (nested) unit isn't mistaken for a deleted one.
+  state.config.data_dir / self.id
 
 proc data_file*(self: Unit): string =
   self.data_dir / self.id & ".json"
@@ -332,6 +333,24 @@ method on_collision*(
 
 method off_collision*(self: Model, partner: Model) {.base, gcsafe.} =
   discard
+
+proc reparent_to_root*(self: Unit) =
+  ## Move `self` out of its current parent's `units` into the top-level
+  ## `state.units`, re-rooting its node and restoring its world transform — the
+  ## reverse of `adopt`. Also used to evacuate a non-owned child when its parent
+  ## is destroyed. `TRANSFERRING` keeps the collection move from being read as a
+  ## delete; it's cleared on the next tick.
+  let parent = self.parent
+  if parent.is_nil:
+    return
+  self.global_flags += TRANSFERRING
+  state.units.add self
+  parent.units -= self
+  self.parent = nil
+  self.global_flags += GLOBAL
+  self.transform_value.origin = self.transform.origin + parent.transform.origin
+  after_boop:
+    self.global_flags -= TRANSFERRING
 
 method destroy*(self: Unit) {.gcsafe.} =
   # Override of ed's EdRef base: a Unit must be destroyed through a concrete

--- a/src/models/units.nim
+++ b/src/models/units.nim
@@ -348,7 +348,9 @@ proc reparent_to_root*(self: Unit) =
   parent.units -= self
   self.parent = nil
   self.global_flags += GLOBAL
-  self.transform_value.origin = self.transform.origin + parent.transform.origin
+  # Local -> world through the parent chain's full transforms: an origin-only
+  # sum would restore the position the unit had before the parent ever rotated.
+  self.transform_value.origin = self.transform.origin.world_from(parent)
   after_boop:
     self.global_flags -= TRANSFERRING
 

--- a/src/nodes/bot_node.nim
+++ b/src/nodes/bot_node.nim
@@ -18,7 +18,7 @@ const SELF_AVATAR_LAYER = 1'i64 shl 19
 
 gdobj BotNode of KinematicBody:
   var
-    model*: Unit
+    model* {.cursor.}: Unit
     material* {.gdExport.},
       highlight_material* {.gdExport.},
       selected_material* {.gdExport.}: Material

--- a/src/nodes/bot_node.nim
+++ b/src/nodes/bot_node.nim
@@ -1,4 +1,4 @@
-import std/[tables, math, os]
+import std/[tables, math, os, options]
 import pkg/godot except print
 import pkg/[chroma]
 import
@@ -8,8 +8,26 @@ import
     text_edit, camera, viewport, texture, image, visual_server, voxel_viewer,
     area, ray_cast,
   ]
-import gdutils, core, models/[colors, units], ui/markdown_label
+import gdutils, core, models/[colors, units, builds], ui/markdown_label
 import ./queries
+
+const climb_speed = 10.0
+  ## How fast a bot rises onto a block (units/sec) — the climb is animated at
+  ## this rate (~0.1s per block) instead of snapping; the drop back down is
+  ## animated by gravity.
+
+const foot_offset = 0.0
+  ## How far a bot's origin sits above the surface it stands on — the target for
+  ## the vertical floor-follow (surface top + this). The bot's feet are AT its
+  ## origin (the collision capsule spans 0..1.75 upward from it), verified
+  ## visually: origin = surface top reads as standing; +1 floats a full voxel.
+
+proc solid_at(build: Build, cell: Vector3): bool =
+  ## Is this build-local grid cell a solid (standable) voxel?
+  if cell notin build:
+    return false
+  let info = build.voxel_info(cell)
+  info.kind != HOLE and info.color != ACTION_COLORS[ERASER]
 
 const SELF_AVATAR_LAYER = 1'i64 shl 19
   ## Render layer for the local player's own avatar: the player's first-person
@@ -37,11 +55,14 @@ gdobj BotNode of KinematicBody:
     # Platform transform-matching: carry the bot by the rigid motion of the build
     # under its feet (rotation + translation) so it rides a moving/turning
     # platform while staying a world-space body — its coordinates never change.
-    # `down_ray` finds the surface; we track its node id + world transform to
-    # apply each frame's delta. (Riding static ground is a zero-delta no-op.)
-    down_ray: RayCast
+    # The floor is found by querying voxel data (not a physics ray: colliders
+    # are only cooked near viewers, so a ray finds nothing away from the player
+    # and the bot would fall through the world). We track the floor node's id +
+    # world transform to apply each frame's delta.
     floor_prev_id: int64
     floor_prev_transform: Transform
+    fall_velocity: float # node-side fake gravity for walking off ledges
+    floor_seen: bool # gravity only starts once the bot has stood on something
 
   proc update_material*(value: Material) =
     self.mesh.set_surface_material(0, value)
@@ -193,14 +214,6 @@ gdobj BotNode of KinematicBody:
 
     if self.model of Bot:
       let bot = Bot(self.model)
-
-      # Downward ray for platform-riding: finds the build directly underfoot.
-      # Mask 5 = the build/ground layers (same as the player's DownRay).
-      self.down_ray = gdnew[RayCast]()
-      self.down_ray.enabled = true
-      self.down_ray.cast_to = vec3(0, -1.95, 0)
-      self.down_ray.collision_mask = 5
-      self.add_child(self.down_ray)
 
       # Unit queries are answered only by the server. A connected client also
       # holds the synced bot (and its query_value); answering here too makes
@@ -369,31 +382,153 @@ gdobj BotNode of KinematicBody:
           # back the prior frame's ortho render.
           self.screenshot_warmup_frames = 2
 
-  proc ride_platform() =
-    ## Transform-matching: carry the bot by the world-space rigid motion of the
-    ## surface under its feet, so it rides a moving/turning platform. The bot
-    ## stays a world-space body (no reparenting), so its coordinates never change
-    ## under the script. Applied after the bot's own walk, so walking and riding
-    ## compose. Detection is the down-ray; static ground gives a zero delta.
-    if self.down_ray.is_nil:
+  proc find_floor(
+      reach: float, reach_up = 0.0
+  ): Option[tuple[node: Spatial, top: float32]] =
+    ## The surface under the bot's feet within `reach` below them (or, with
+    ## `reach_up`, embedded up to that far above them — how a walked-into step
+    ## is climbed): build voxels or the world ground plane (y = 0). Queried
+    ## from voxel data, NOT physics colliders — those are only cooked near
+    ## viewers, so a ray finds nothing away from the player. Returns the
+    ## surface's node (nil for the ground) and its world-space top height.
+    let pos = self.global_transform.origin
+    let feet = pos.y - foot_offset
+    # Sample top-down so the highest surface wins (a step above the feet beats
+    # the floor below). Half-voxel steps can't skip a full-height slab (a thin
+    # *scaled-down* slab could slip through — rare, accepted).
+    var dy = -reach_up
+    while dy <= reach:
+      let sample = vec3(pos.x, feet - 0.01 - dy, pos.z)
+      for unit in state.units.value:
+        if unit of Build and ?unit.node:
+          let bnode = Spatial(unit.node)
+          # Through the node's full transform, so rotated/scaled builds
+          # (turning barges) resolve correctly — model local_to is origin-only.
+          let local = bnode.global_transform.xform_inv_vector3(sample)
+          let cell = vec3(floor(local.x), floor(local.y), floor(local.z))
+          if Build(unit).solid_at(cell):
+            let top = bnode.global_transform.xform_vector3(
+              vec3(local.x, cell.y + 1.0, local.z)
+            ).y
+            return some((node: bnode, top: top))
+      if ?state.ground and sample.y <= 0.0:
+        return some((node: Spatial(nil), top: 0.0'f32))
+      dy += 0.5
+
+  proc climb_step(floor_top: float32): Option[float32] =
+    ## The world top of a single climbable block directly in the bot's walking
+    ## path: solid at shin height just ahead, with headroom above it (so walls
+    ## two or more blocks tall still block). A walking bot needs this probe —
+    ## where colliders exist (near the player) move_and_slide stops it at the
+    ## block's face, so its feet never embed and find_floor's reach_up never
+    ## sees the step. Anchored to the STANDING floor, not the bot's current
+    ## feet: mid-climb the feet are already lifted, and a feet-relative probe
+    ## would scan above the step, lose it, and drop the bot — an oscillation.
+    if not (self.model of Bot):
       return
-    self.down_ray.force_raycast_update
-    let platform =
-      if self.down_ray.is_colliding: self.down_ray.get_collider as Spatial
-      else: nil
-    if platform.is_nil:
-      self.floor_prev_id = 0
+    var dir = Bot(self.model).velocity
+    dir.y = 0
+    if dir.length < 0.1:
       return
     let
-      id = platform.get_instance_id
-      now = platform.global_transform
-    # Skip a static surface: `now * now.inverse` isn't exactly identity in
-    # float32, so applying it every frame would slowly drift the bot.
-    if id == self.floor_prev_id and now != self.floor_prev_transform:
-      let delta = now * self.floor_prev_transform.affine_inverse
-      self.global_transform = delta * self.global_transform
-    self.floor_prev_id = id
-    self.floor_prev_transform = now
+      pos = self.global_transform.origin
+      ahead = pos + dir.normalized * 0.6
+      probe = vec3(ahead.x, floor_top + 0.45, ahead.z)
+    for unit in state.units.value:
+      if unit of Build and ?unit.node:
+        let
+          build = Build(unit)
+          bnode = Spatial(unit.node)
+          local = bnode.global_transform.xform_inv_vector3(probe)
+          cell = vec3(floor(local.x), floor(local.y), floor(local.z))
+        if build.solid_at(cell) and not build.solid_at(cell + vec3(0, 1, 0)):
+          let top = bnode.global_transform.xform_vector3(
+            vec3(local.x, cell.y + 1.0, local.z)
+          ).y
+          if top > floor_top + 0.05 and top <= floor_top + 1.1:
+            return some(top)
+
+  proc ride_and_fall(delta: float) =
+    ## Two node-side, world-space (no reparenting) behaviours off one floor
+    ## query:
+    ## - Ride: carry the bot by the rigid motion (rotation + translation) of the
+    ##   surface under its feet, so it rides a moving/turning platform.
+    ## - Floor-follow: keep the bot on that surface vertically — step up onto
+    ##   blocks, and fall off ledges under a fake gravity matching the player's.
+    ## Horizontal (walk + ride) and vertical (this) are independent; the script's
+    ## turtle moves own X/Z, this owns Y. Applied after the bot's own walk.
+    if LOADING_LEVEL in state.global_flags:
+      return
+    # Fell out of the world (genuinely bottomless): reset high instead of a
+    # runaway free-fall to -inf.
+    if self.translation.y < -50:
+      var t = self.translation
+      t.y = 30
+      self.translation = t
+      self.fall_velocity = 0.0
+      return
+    # Look past this frame's fall step: a long fall drops more per frame than a
+    # fixed reach, so it would step across a floor between frames (tunnel).
+    # When grounded, also look one block up, so a step the bot has walked into
+    # (feet embedded) is climbed; never while falling, so dropping past a
+    # ledge's edge doesn't yank the bot up onto it.
+    let next_fall = self.fall_velocity + state.gravity * delta
+    let reach_up = if self.fall_velocity < 0: 0.0 else: 0.99
+    let floor_hit = self.find_floor(1.0 - next_fall * delta, reach_up)
+    if floor_hit.is_none:
+      # Nothing underfoot. Only fall if we've stood on something before — a bot
+      # placed in mid-air (or mid level-load) should wait, not drop forever.
+      self.floor_prev_id = 0
+      if self.floor_seen:
+        self.fall_velocity = next_fall
+        var t = self.translation
+        t.y += self.fall_velocity * delta
+        self.translation = t
+      return
+    self.floor_seen = true
+    var target_y = floor_hit.get.top + foot_offset
+    if self.fall_velocity >= 0:
+      # A single block in the walking path becomes the floor target: the bot
+      # lifts onto it while its center is still behind the block's face (the
+      # probe keeps seeing the step ahead), and the walk carries it across.
+      # Skipped while falling, so dropping past a ledge isn't yanked sideways.
+      let step = self.climb_step(floor_hit.get.top)
+      if step.is_some and step.get > target_y:
+        target_y = step.get
+    block:
+      var t = self.translation
+      if t.y > target_y + 0.01:
+        # Airborne above the surface (walked off / stepping down) — fall toward
+        # it, landing exactly on it. No ride carry while airborne.
+        self.floor_prev_id = 0
+        self.fall_velocity = next_fall
+        t.y = max(t.y + self.fall_velocity * delta, target_y)
+        if t.y == target_y:
+          self.fall_velocity = 0.0
+        self.translation = t
+        return
+    self.fall_velocity = 0.0
+    let fnode = floor_hit.get.node
+    if fnode.is_nil:
+      # The ground plane — static, nothing to ride.
+      self.floor_prev_id = 0
+    else:
+      let
+        id = fnode.get_instance_id
+        now = fnode.global_transform
+      # Ride (horizontal + rotation). Skip a static surface: `now * now.inverse`
+      # isn't exactly identity in float32, so applying it every frame would
+      # drift.
+      if id == self.floor_prev_id and now != self.floor_prev_transform:
+        let motion = now * self.floor_prev_transform.affine_inverse
+        self.global_transform = motion * self.global_transform
+      self.floor_prev_id = id
+      self.floor_prev_transform = now
+    # Settle / step up onto the surface. Rising (climb, step-up) is animated at
+    # climb_speed rather than snapped; already-settled stays pinned exactly.
+    var t = self.translation
+    t.y = min(t.y + climb_speed * delta, target_y)
+    self.translation = t
 
   method process(delta: float) =
     # Render-tick only: the screenshot warm-up counts render frames. Movement and
@@ -410,7 +545,7 @@ gdobj BotNode of KinematicBody:
         # whether or not it's running a script.
         if SCRIPT_RUNNING in self.model.global_flags and bot.velocity.length > 0:
           discard self.move_and_slide(self.model.velocity, UP)
-        self.ride_platform()
+        self.ride_and_fall(delta)
       if self.model.code.owner == state.worker_ctx_name:
         self.model.transform_value.pause self.transform_zid:
           self.model.transform = self.transform

--- a/src/nodes/bot_node.nim
+++ b/src/nodes/bot_node.nim
@@ -122,12 +122,6 @@ gdobj BotNode of KinematicBody:
       ) or SCRIPT_INITIALIZING.removed:
         self.set_visibility
 
-      if self.model of Bot:
-        if SCRIPT_RUNNING.added:
-          self.set_process(true)
-        elif SCRIPT_RUNNING.removed:
-          self.set_process(false)
-
     self.model.local_flags.watch:
       if HIGHLIGHT.added:
         self.highlight()
@@ -217,9 +211,13 @@ gdobj BotNode of KinematicBody:
       if serves_queries:
         info "agent bot node setup",
           id = bot.id, has_query_value = ?bot.query_value
-      self.set_process(
-        SCRIPT_RUNNING in self.model.global_flags or serves_queries
-      )
+      # Bots always run both ticks: physics_process drives movement + riding (on
+      # the same 60Hz tick as the platform and player, so riding is smooth), and
+      # process drives the screenshot warm-up (render-tick work). Gating either on
+      # SCRIPT_RUNNING used to leave non-scripted bots asleep — the node never
+      # acted on the model — so they didn't ride or, on a flag/watch race, move.
+      self.set_process(true)
+      self.set_physics_process(true)
       # A VOXEL_VIEWER unit streams voxel terrain around itself, so screenshots
       # render even when no player is nearby. Server-side only: that's
       # where queries (and their renders) are served. (Qualified: in Nim
@@ -240,6 +238,7 @@ gdobj BotNode of KinematicBody:
     ## the player's own camera culls it while every other camera renders it,
     ## shadow and all.
     self.set_process(false)
+    self.set_physics_process(false)
     self.collision_layer = 0
     self.collision_mask = 0
     # The body isn't the only collider: bots are targeted through their
@@ -397,12 +396,19 @@ gdobj BotNode of KinematicBody:
     self.floor_prev_transform = now
 
   method process(delta: float) =
+    # Render-tick only: the screenshot warm-up counts render frames. Movement and
+    # riding moved to physics_process so they share the platform's (and player's)
+    # tick — see physics_process.
     self.process_screenshot()
 
+  method physics_process(delta: float) =
     if ?self.model:
       if self.model of Bot:
         let bot = Bot(self.model)
-        if bot.velocity.length > 0:
+        # Move only while a script is driving the bot, so it stops when the
+        # script ends. Riding is independent: a bot rides whatever it stands on
+        # whether or not it's running a script.
+        if SCRIPT_RUNNING in self.model.global_flags and bot.velocity.length > 0:
           discard self.move_and_slide(self.model.velocity, UP)
         self.ride_platform()
       if self.model.code.owner == state.worker_ctx_name:

--- a/src/nodes/bot_node.nim
+++ b/src/nodes/bot_node.nim
@@ -11,12 +11,12 @@ import
 import gdutils, core, models/[colors, units, builds], ui/markdown_label
 import ./queries
 
-const climb_speed = 10.0
+const CLIMB_SPEED = 10.0
   ## How fast a bot rises onto a block (units/sec) — the climb is animated at
   ## this rate (~0.1s per block) instead of snapping; the drop back down is
   ## animated by gravity.
 
-const foot_offset = 0.0
+const FOOT_OFFSET = 0.0
   ## How far a bot's origin sits above the surface it stands on — the target for
   ## the vertical floor-follow (surface top + this). The bot's feet are AT its
   ## origin (the collision capsule spans 0..1.75 upward from it), verified
@@ -382,8 +382,18 @@ gdobj BotNode of KinematicBody:
           # back the prior frame's ortho render.
           self.screenshot_warmup_frames = 2
 
+  proc scan_builds(): seq[Build] =
+    ## Every build in the level with a live node, nested included —
+    ## script-spawned instances and adopted builds live under other units, not
+    ## at the top level, and bots must stand on those too.
+    var found: seq[Build]
+    state.units.value.walk_tree proc(unit: Unit) {.gcsafe.} =
+      if unit of Build and ?unit.node:
+        found.add Build(unit)
+    found
+
   proc find_floor(
-      reach: float, reach_up = 0.0
+      builds: seq[Build], reach: float, reach_up = 0.0
   ): Option[tuple[node: Spatial, top: float32]] =
     ## The surface under the bot's feet within `reach` below them (or, with
     ## `reach_up`, embedded up to that far above them — how a walked-into step
@@ -392,30 +402,29 @@ gdobj BotNode of KinematicBody:
     ## viewers, so a ray finds nothing away from the player. Returns the
     ## surface's node (nil for the ground) and its world-space top height.
     let pos = self.global_transform.origin
-    let feet = pos.y - foot_offset
+    let feet = pos.y - FOOT_OFFSET
     # Sample top-down so the highest surface wins (a step above the feet beats
     # the floor below). Half-voxel steps can't skip a full-height slab (a thin
     # *scaled-down* slab could slip through — rare, accepted).
     var dy = -reach_up
     while dy <= reach:
       let sample = vec3(pos.x, feet - 0.01 - dy, pos.z)
-      for unit in state.units.value:
-        if unit of Build and ?unit.node:
-          let bnode = Spatial(unit.node)
-          # Through the node's full transform, so rotated/scaled builds
-          # (turning barges) resolve correctly — model local_to is origin-only.
-          let local = bnode.global_transform.xform_inv_vector3(sample)
-          let cell = vec3(floor(local.x), floor(local.y), floor(local.z))
-          if Build(unit).solid_at(cell):
-            let top = bnode.global_transform.xform_vector3(
-              vec3(local.x, cell.y + 1.0, local.z)
-            ).y
-            return some((node: bnode, top: top))
+      for build in builds:
+        let bnode = Spatial(build.node)
+        # Through the node's full transform, so rotated/scaled builds
+        # (turning barges) resolve correctly — model local_to is origin-only.
+        let local = bnode.global_transform.xform_inv_vector3(sample)
+        let cell = vec3(floor(local.x), floor(local.y), floor(local.z))
+        if build.solid_at(cell):
+          let top = bnode.global_transform.xform_vector3(
+            vec3(local.x, cell.y + 1.0, local.z)
+          ).y
+          return some((node: bnode, top: top))
       if ?state.ground and sample.y <= 0.0:
         return some((node: Spatial(nil), top: 0.0'f32))
       dy += 0.5
 
-  proc climb_step(floor_top: float32): Option[float32] =
+  proc climb_step(builds: seq[Build], floor_top: float32): Option[float32] =
     ## The world top of a single climbable block directly in the bot's walking
     ## path: solid at shin height just ahead, with headroom above it (so walls
     ## two or more blocks tall still block). A walking bot needs this probe —
@@ -434,19 +443,17 @@ gdobj BotNode of KinematicBody:
       pos = self.global_transform.origin
       ahead = pos + dir.normalized * 0.6
       probe = vec3(ahead.x, floor_top + 0.45, ahead.z)
-    for unit in state.units.value:
-      if unit of Build and ?unit.node:
-        let
-          build = Build(unit)
-          bnode = Spatial(unit.node)
-          local = bnode.global_transform.xform_inv_vector3(probe)
-          cell = vec3(floor(local.x), floor(local.y), floor(local.z))
-        if build.solid_at(cell) and not build.solid_at(cell + vec3(0, 1, 0)):
-          let top = bnode.global_transform.xform_vector3(
-            vec3(local.x, cell.y + 1.0, local.z)
-          ).y
-          if top > floor_top + 0.05 and top <= floor_top + 1.1:
-            return some(top)
+    for build in builds:
+      let
+        bnode = Spatial(build.node)
+        local = bnode.global_transform.xform_inv_vector3(probe)
+        cell = vec3(floor(local.x), floor(local.y), floor(local.z))
+      if build.solid_at(cell) and not build.solid_at(cell + vec3(0, 1, 0)):
+        let top = bnode.global_transform.xform_vector3(
+          vec3(local.x, cell.y + 1.0, local.z)
+        ).y
+        if top > floor_top + 0.05 and top <= floor_top + 1.1:
+          return some(top)
 
   proc ride_and_fall(delta: float) =
     ## Two node-side, world-space (no reparenting) behaviours off one floor
@@ -458,6 +465,12 @@ gdobj BotNode of KinematicBody:
     ## Horizontal (walk + ride) and vertical (this) are independent; the script's
     ## turtle moves own X/Z, this owns Y. Applied after the bot's own walk.
     if LOADING_LEVEL in state.global_flags:
+      return
+    # An explicitly-adopted (nested) bot is carried by the scene graph — that's
+    # the point of adopt. This proc's math is world-space (translation would be
+    # parent-local here, and the ride would re-apply motion the engine already
+    # composed), so it must not run for nested bots.
+    if ?self.model.parent:
       return
     # Fell out of the world (genuinely bottomless): reset high instead of a
     # runaway free-fall to -inf.
@@ -474,7 +487,8 @@ gdobj BotNode of KinematicBody:
     # ledge's edge doesn't yank the bot up onto it.
     let next_fall = self.fall_velocity + state.gravity * delta
     let reach_up = if self.fall_velocity < 0: 0.0 else: 0.99
-    let floor_hit = self.find_floor(1.0 - next_fall * delta, reach_up)
+    let builds = self.scan_builds()
+    let floor_hit = self.find_floor(builds, 1.0 - next_fall * delta, reach_up)
     if floor_hit.is_none:
       # Nothing underfoot. Only fall if we've stood on something before — a bot
       # placed in mid-air (or mid level-load) should wait, not drop forever.
@@ -486,13 +500,13 @@ gdobj BotNode of KinematicBody:
         self.translation = t
       return
     self.floor_seen = true
-    var target_y = floor_hit.get.top + foot_offset
+    var target_y = floor_hit.get.top + FOOT_OFFSET
     if self.fall_velocity >= 0:
       # A single block in the walking path becomes the floor target: the bot
       # lifts onto it while its center is still behind the block's face (the
       # probe keeps seeing the step ahead), and the walk carries it across.
       # Skipped while falling, so dropping past a ledge isn't yanked sideways.
-      let step = self.climb_step(floor_hit.get.top)
+      let step = self.climb_step(builds, floor_hit.get.top)
       if step.is_some and step.get > target_y:
         target_y = step.get
     block:
@@ -525,9 +539,9 @@ gdobj BotNode of KinematicBody:
       self.floor_prev_id = id
       self.floor_prev_transform = now
     # Settle / step up onto the surface. Rising (climb, step-up) is animated at
-    # climb_speed rather than snapped; already-settled stays pinned exactly.
+    # CLIMB_SPEED rather than snapped; already-settled stays pinned exactly.
     var t = self.translation
-    t.y = min(t.y + climb_speed * delta, target_y)
+    t.y = min(t.y + CLIMB_SPEED * delta, target_y)
     self.translation = t
 
   method process(delta: float) =

--- a/src/nodes/bot_node.nim
+++ b/src/nodes/bot_node.nim
@@ -6,7 +6,7 @@ import
     scene_tree, kinematic_body, material, mesh_instance, spatial, input_event,
     animation_player, resource_loader, packed_scene, spatial_material,
     text_edit, camera, viewport, texture, image, visual_server, voxel_viewer,
-    area,
+    area, ray_cast,
   ]
 import gdutils, core, models/[colors, units], ui/markdown_label
 import ./queries
@@ -34,6 +34,14 @@ gdobj BotNode of KinematicBody:
     # Bot hides its own skin during capture so it doesn't fill its own POV
     # when the camera sits near the bot's body (screenshot, screenshot_at).
     skin_hidden_during_screenshot: bool
+    # Platform transform-matching: carry the bot by the rigid motion of the build
+    # under its feet (rotation + translation) so it rides a moving/turning
+    # platform while staying a world-space body — its coordinates never change.
+    # `down_ray` finds the surface; we track its node id + world transform to
+    # apply each frame's delta. (Riding static ground is a zero-delta no-op.)
+    down_ray: RayCast
+    floor_prev_id: int64
+    floor_prev_transform: Transform
 
   proc update_material*(value: Material) =
     self.mesh.set_surface_material(0, value)
@@ -191,6 +199,15 @@ gdobj BotNode of KinematicBody:
 
     if self.model of Bot:
       let bot = Bot(self.model)
+
+      # Downward ray for platform-riding: finds the build directly underfoot.
+      # Mask 5 = the build/ground layers (same as the player's DownRay).
+      self.down_ray = gdnew[RayCast]()
+      self.down_ray.enabled = true
+      self.down_ray.cast_to = vec3(0, -1.95, 0)
+      self.down_ray.collision_mask = 5
+      self.add_child(self.down_ray)
+
       # Unit queries are answered only by the server. A connected client also
       # holds the synced bot (and its query_value); answering here too makes
       # two writers race on the same synced response container — seen live as
@@ -353,17 +370,44 @@ gdobj BotNode of KinematicBody:
           # back the prior frame's ortho render.
           self.screenshot_warmup_frames = 2
 
+  proc ride_platform() =
+    ## Transform-matching: carry the bot by the world-space rigid motion of the
+    ## surface under its feet, so it rides a moving/turning platform. The bot
+    ## stays a world-space body (no reparenting), so its coordinates never change
+    ## under the script. Applied after the bot's own walk, so walking and riding
+    ## compose. Detection is the down-ray; static ground gives a zero delta.
+    if self.down_ray.is_nil:
+      return
+    self.down_ray.force_raycast_update
+    let platform =
+      if self.down_ray.is_colliding: self.down_ray.get_collider as Spatial
+      else: nil
+    if platform.is_nil:
+      self.floor_prev_id = 0
+      return
+    let
+      id = platform.get_instance_id
+      now = platform.global_transform
+    # Skip a static surface: `now * now.inverse` isn't exactly identity in
+    # float32, so applying it every frame would slowly drift the bot.
+    if id == self.floor_prev_id and now != self.floor_prev_transform:
+      let delta = now * self.floor_prev_transform.affine_inverse
+      self.global_transform = delta * self.global_transform
+    self.floor_prev_id = id
+    self.floor_prev_transform = now
+
   method process(delta: float) =
     self.process_screenshot()
 
     if ?self.model:
-      if self.model.code.owner == state.worker_ctx_name:
-        self.model.transform_value.pause self.transform_zid:
-          self.model.transform = self.transform
       if self.model of Bot:
         let bot = Bot(self.model)
         if bot.velocity.length > 0:
           discard self.move_and_slide(self.model.velocity, UP)
+        self.ride_platform()
+      if self.model.code.owner == state.worker_ctx_name:
+        self.model.transform_value.pause self.transform_zid:
+          self.model.transform = self.transform
 
 var bot_scene {.threadvar.}: PackedScene
 proc init*(_: type BotNode): BotNode =

--- a/src/nodes/build_node.nim
+++ b/src/nodes/build_node.nim
@@ -321,7 +321,12 @@ gdobj BuildNode of VoxelTerrain:
 
   method process(delta: float) =
     if ?self.model:
-      if self.model.code.owner == state.worker_ctx_name:
+      # Sync node->model only when the script isn't driving us this frame. While a
+      # model->node update is pending (applied next physics_process), the node is
+      # a frame stale, so writing it back would fight the script and bounce. With
+      # no pending, this still carries node-side edits to the model.
+      if self.model.code.owner == state.worker_ctx_name and
+          self.pending_transform.is_none:
         self.model.transform_value.pause self.transform_zid:
           self.model.transform = self.transform
 

--- a/src/nodes/build_node.nim
+++ b/src/nodes/build_node.nim
@@ -22,6 +22,13 @@ gdobj BuildNode of VoxelTerrain:
   var
     model* {.cursor.}: Build
     transform_zid: EID
+    # A model transform change is recorded here and applied in physics_process,
+    # not in the watch (which fires on the render tick), so the node moves on the
+    # same 60Hz tick as riders read it — smooth riding. Only set on a real model
+    # change, so it never overwrites a node-side edit (those sync node->model in
+    # process, with the watch paused).
+    pending_transform: Option[Transform]
+    positioned: bool # initial placement applied? (see the transform watch)
     default_view_distance: int
     toggle_error_highlight_at = MonoTime.high
     error_highlight_on: bool
@@ -285,7 +292,14 @@ gdobj BuildNode of VoxelTerrain:
 
     self.transform_zid = self.model.transform_value.watch:
       if added:
-        self.transform = change.item
+        if self.positioned:
+          self.pending_transform = some(change.item)
+        else:
+          # Apply the initial placement immediately so the build doesn't flash at
+          # the origin for a frame; later (movement) changes defer to the physics
+          # tick for smooth riding.
+          self.transform = change.item
+          self.positioned = true
 
     self.model.sight_query_value.watch:
       if added:
@@ -295,6 +309,15 @@ gdobj BuildNode of VoxelTerrain:
         query.run(self.model)
         self.collision_layer = collision_layer
         self.model.sight_query = query
+
+  method physics_process(delta: float) =
+    # Apply a recorded model transform on the physics tick, so a rider reading us
+    # in its own physics_process samples a value that advanced on the same 60Hz
+    # tick — no render-vs-physics jitter. Cleared after applying so it can't
+    # overwrite a later node-side edit.
+    if self.pending_transform.is_some:
+      self.transform = self.pending_transform.get
+      self.pending_transform = none(Transform)
 
   method process(delta: float) =
     if ?self.model:

--- a/src/nodes/build_node.nim
+++ b/src/nodes/build_node.nim
@@ -20,7 +20,7 @@ var hidden_shader {.threadvar.}: Shader
 
 gdobj BuildNode of VoxelTerrain:
   var
-    model*: Build
+    model* {.cursor.}: Build
     transform_zid: EID
     default_view_distance: int
     toggle_error_highlight_at = MonoTime.high

--- a/src/nodes/player_node.nim
+++ b/src/nodes/player_node.nim
@@ -70,6 +70,13 @@ gdobj PlayerNode of KinematicBody:
     model* {.cursor.}: Player
     velocity_zid, rotation_zid: EID
     boosted = false
+    # Platform transform matching: the build we're standing on and its world
+    # transform last frame, so we ride it by that frame's rigid motion —
+    # translation plus the orbit from its rotation — while staying a world-space
+    # body. `floor_build_velocity` is kept for the jump-momentum bake.
+    floor_build_id: string
+    floor_prev_transform: Transform
+    floor_build_velocity*: Vector3
     # touch_time = MonoTime.low
     touch_position: Option[Vector2]
     delete_timer = MonoTime.high
@@ -262,6 +269,48 @@ gdobj PlayerNode of KinematicBody:
         self.get_slide_collision(i)
 
     handle_collisions(self.model, collisions)
+
+    # Platform transform matching: if we're standing on a build, ride it by its
+    # world-space rigid motion this frame — translation plus the orbit from its
+    # rotation — so we move with a moving/turning floor while staying a world-
+    # space body (position only; the body basis and camera are left alone).
+    # `floor_build_velocity` is kept so a jump inherits the platform's momentum.
+    block:
+      var floor_node: Spatial
+      var floor_id: string
+      for col in collisions:
+        if col.normal.y > 0.7:
+          let m = col.collider.model
+          if not m.is_nil and m of Build:
+            floor_node = col.collider as Spatial
+            floor_id = m.id
+            break
+      if floor_node.is_nil:
+        self.floor_build_id = ""
+        self.floor_build_velocity = vec3()
+      else:
+        let now = floor_node.global_transform
+        # Skip a static surface: `now * now.inverse` isn't exactly identity in
+        # float32, so applying it every frame would slowly drift us.
+        if floor_id == self.floor_build_id and now != self.floor_prev_transform:
+          let
+            motion = now * self.floor_prev_transform.affine_inverse
+            new_origin = motion.xform_vector3(self.translation)
+            move = new_origin - self.translation
+          self.floor_build_velocity =
+            if delta > 0: move / delta.float32 else: vec3()
+          self.translation = new_origin
+          # Turn our view with the platform's yaw, like standing on a turning
+          # barge. Added to the look, so it composes with mouse-look (applied in
+          # `process`); `process` then syncs it to `model.rotation`.
+          var look = self.camera_rig.rotation
+          look.y += motion.basis.get_euler.y
+          self.camera_rig.rotation = look
+          self.model.transform = self.transform
+        elif floor_id != self.floor_build_id:
+          self.floor_build_velocity = vec3()
+        self.floor_build_id = floor_id
+        self.floor_prev_transform = now
 
     if process_input:
       if self.is_on_floor:

--- a/src/nodes/player_node.nim
+++ b/src/nodes/player_node.nim
@@ -67,7 +67,7 @@ gdobj PlayerNode of KinematicBody:
     index = 0
     collision_shape: CollisionShape
     command_timer = 0.0
-    model*: Player
+    model* {.cursor.}: Player
     velocity_zid, rotation_zid: EID
     boosted = false
     # touch_time = MonoTime.low

--- a/src/nodes/player_node.nim
+++ b/src/nodes/player_node.nim
@@ -77,6 +77,7 @@ gdobj PlayerNode of KinematicBody:
     floor_build_id: string
     floor_prev_transform: Transform
     floor_build_velocity*: Vector3
+    floor_static_frames: int
     # touch_time = MonoTime.low
     touch_position: Option[Vector2]
     delete_timer = MonoTime.high
@@ -309,6 +310,18 @@ gdobj PlayerNode of KinematicBody:
           self.model.transform = self.transform
         elif floor_id != self.floor_build_id:
           self.floor_build_velocity = vec3()
+          self.floor_static_frames = 0
+        else:
+          # Same floor, no motion this frame. Platform transforms arrive at the
+          # worker's cadence, so a moving platform legitimately skips the odd
+          # physics frame — but a platform that has *stopped* must not leave its
+          # last-frame velocity baked into a later jump (launching the player
+          # sideways off a stationary surface). Clear after a short static run.
+          inc self.floor_static_frames
+          if self.floor_static_frames >= 10:
+            self.floor_build_velocity = vec3()
+        if now != self.floor_prev_transform:
+          self.floor_static_frames = 0
         self.floor_build_id = floor_id
         self.floor_prev_transform = now
 

--- a/src/nodes/sign_node.nim
+++ b/src/nodes/sign_node.nim
@@ -12,7 +12,7 @@ const
   viewport_y = 1200
 
 gdobj SignNode of Spatial:
-  var model*: Sign
+  var model* {.cursor.}: Sign
   var zid: EID
   var material: SpatialMaterial
   var viewport: Viewport

--- a/src/types.nim
+++ b/src/types.nim
@@ -153,6 +153,14 @@ type
       ## player is nearby. Off by default — players bring their own viewer,
       ## and most units don't need one. Set it on agent bots that take
       ## screenshots away from the player.
+    TRANSFERRING
+      ## Transient: the unit is being moved between units collections (see
+      ## `adopt`/`release`). Set across the collection remove/add so the
+      ## destroy-on-remove watchers (node controller + worker) detach/re-attach
+      ## the node instead of tearing the unit down. Synced (SYNC_REMOTE, via
+      ## GlobalModelFlags) because every context applies the membership move and
+      ## runs the same ungated destroy. Interim until destructor-driven teardown
+      ## (getenu/enu#65) makes remove==detach; then this flag goes away.
 
   Tools* = enum
     CODE_MODE
@@ -295,6 +303,12 @@ type
     velocity_value*: EdValue[Vector3]
     transform_value*: EdValue[Transform]
     clone_of*: Unit
+    spawned_by*: string
+      ## Id of the unit whose script `.new()`'d this instance, set once at
+      ## creation and never changed. Distinguishes *my* instances from foreign
+      ## ones (both have `clone_of`): when a unit is destroyed, only children
+      ## with `spawned_by == self.id` go down with it; everything else (real
+      ## units, the player, instances spawned elsewhere) is re-rooted.
     collisions*: EdSeq[tuple[id: string, normal: Vector3]]
     shared_value*: EdValue[Shared]
     start_color*: Color

--- a/src/ui/gui.nim
+++ b/src/ui/gui.nim
@@ -153,7 +153,10 @@ gdobj GUI of Control:
         player.jump_time = nil_time
         state.toggle_flag(FLYING)
       elif player.is_on_floor():
-        player.velocity += vec3(0, jump_impulse, 0)
+        # Jump, inheriting the floor build's velocity so a jump off a moving
+        # platform carries its momentum through the arc. Zero on a static floor
+        # or the ground.
+        player.velocity += vec3(0, jump_impulse, 0) + player.floor_build_velocity
         player.jump_time = some time
       else:
         player.jump_time = some time

--- a/tasks.nim
+++ b/tasks.nim
@@ -157,10 +157,8 @@ task build, "Build enu":
       else:
         ""
   exec &"nim c -o:{output}{cross_opts}{extra} src/enu.nim"
-  # Also build the MCP server for dev runs. dist builds + bundles it per-platform
-  # below, so skip the redundant copy there.
-  if "-d:dist" notin command_line_params():
-    build_mcp()
+  # The MCP server (`bin/enu`) builds separately — `nim build_mcp`. dist_package
+  # bundles it per-platform; the MCP tests compile it themselves (`nim r`).
 
 task build_godot, "Build godot. Use --force to re-init submodules":
   build_godot(force = "--force" in command_line_params())
@@ -356,7 +354,9 @@ task mcp_repro,
 
 task test_mcp, "run MCP integration tests (launches a private Enu)":
   # The test self-launches a minimized Enu on a free port and tears it down, so
-  # no manually-running Enu is needed. Assumes the app is already built.
+  # no manually-running Enu is needed. It compiles + runs the MCP server itself
+  # (`nim r ./bin/enu.nim mcp`), so it needs no prebuilt `bin/enu`; it does assume
+  # the game lib is already built (`nim build`).
   exec "nim c -r tests/mcp/enu_mcp_test.nim"
 
 proc run_tests(names: openArray[string]) =


### PR DESCRIPTION
Bots and the player now stick to moving platforms, and bots handle vertical terrain: they fall off ledges and climb single blocks. Everything runs on the physics tick, so riding is smooth. Verified live in-world throughout (MCP eval + screenshots), plus a high-effort adversarial review of the final diff with fixes.

## Riding: transform matching, not reparenting
Each physics frame, the world-space rigid motion (translation **and rotation**) of the surface underfoot is applied to the rider. Riders stay world-space bodies, so **coordinates never change under the coder** — a GLOBAL unit keeps world coords, an instance keeps its parent's space. It's also the topology the coming physics engine (Jolt, next release) inherits: the manual carry gets replaced by friction/contact rather than unwound.

- **Bots** ride whatever they stand on — still or walking (turtle commands compose with the carry), orbiting and yawing 1:1 with a turning platform.
- **The player** rides the same way, turns its view with the platform's yaw (composing with mouse-look), and inherits the platform's velocity when jumping off.
- Bot + build movement moved to `physics_process` so rider and platform advance on one tick — this is what killed the ride wobble.

## Bot floor-follow
One voxel-data floor query (no physics rays — colliders only exist near viewers, so rays fail away from the player) drives both riding and vertical behavior:
- Walk off a ledge → fall under gravity matching the player's, landing exactly.
- Walk into a single block → animated hop up (`CLIMB_SPEED`); 2+-block walls still block.
- Gravity only starts once a bot has stood on something (no falling during level load / mid-air placement); out-of-world falls reset instead of running to −inf.
- Rotated/scaled platforms resolve exactly (full-transform math); placing a bot on a rotated build drops it at the aim point (new `world_from`).

## Explicit `me.adopt(unit)` / `unit.release`
Reparent a unit onto another in one call (de-parenting handled internally); `release` restores its world transform — exact round-trip even on a rotated platform. Supported by: `node.model` as `{.cursor.}` (breaks the unit↔node cycle), a `TRANSFERRING` flag so cross-thread watchers read a move as a move (not a delete), flat `data_dir`, and `spawned_by` so deleting a unit kills its own instances but evacuates foreign riders (recursively).

## Also
- `nim build` builds only enu; the MCP server is `nim build_mcp` (tests compile it themselves; dist bundles it per-platform).
- ed 0.30.2 → 0.30.3.

## Known interim limits (until destructor-driven teardown #65 / Jolt)
- Adoption is top-level-only: adopting an already-nested unit errors ("release it first") instead of silently diverging model and node.
- A genuine delete inside the same-tick `TRANSFERRING` window of the same unit is treated as a move.
- Idle bots now tick every physics frame (accepted trade-off; revisit if thousands-of-bots worlds return).
- Origin-only `global_from`/`local_to` remain in block paths (cross-build transfer, ground-click joining) — self-consistent pairs, but blocks placed on/next to a *rotated* build will misplace; left for a deliberate pass.
