### PR TITLE
feat(tools): script-controlled tool availability

### DIFF
--- a/src/controllers/script_controllers/host_bridge.nim
+++ b/src/controllers/script_controllers/host_bridge.nim
@@ -725,6 +725,18 @@ proc tool(self: Unit): int =
 proc `tool=`(self: Unit, value: int) =
   state.tool = Tools(value)
 
+proc tools_has(self: Unit, tool: int): bool =
+  Tools(tool) in state.tools
+
+proc tools_incl(self: Unit, tool: int) =
+  state.tools += Tools(tool)
+
+proc tools_excl(self: Unit, tool: int) =
+  state.tools -= Tools(tool)
+
+proc tools_clear(self: Unit) =
+  state.tools.clear()
+
 proc open_sign(self: Unit): Sign =
   state.open_sign
 
@@ -1549,7 +1561,8 @@ proc bridge_to_vm*(worker: Worker) =
     size, `size=`, open, `open=`, billboard, `billboard=`
 
   result.bridged_from_vm "players",
-    playing, `playing=`, god, `god=`, flying, `flying=`, tool, `tool=`, coding,
+    playing, `playing=`, god, `god=`, flying, `flying=`, tool, `tool=`,
+    tools_has, tools_incl, tools_excl, tools_clear, coding,
     `coding=`, running, `running=`, open_sign, `open_sign=`, executing_player,
     block_log, clear_block_log
 

--- a/src/controllers/script_controllers/worker.nim
+++ b/src/controllers/script_controllers/worker.nim
@@ -697,10 +697,9 @@ proc worker_thread(params: (EdContext, GameState)) {.gcsafe.} =
         var i = 0
         while i < state.units.len:
           let unit = state.units[i]
-          # EPHEMERAL units encode their owning context name in their id
-          # (`player-{ctx_name}`, `mcp_bot-{ctx_name}`, ...). When the
-          # context unsubscribes, drop the corresponding agents.
-          if EPHEMERAL in unit.global_flags and ctx_name in unit.id:
+          # EPHEMERAL units carry the ctx that created them in `owner_ctx`.
+          # When that context unsubscribes, drop the corresponding agents.
+          if EPHEMERAL in unit.global_flags and unit.owner_ctx == ctx_name:
             debug "reaping agent unit on ctx unsubscribe",
               unit_id = unit.id, ctx_name
             state.units.del i

--- a/src/core.nim
+++ b/src/core.nim
@@ -295,13 +295,21 @@ proc init*(_: type Code, nim: string): Code =
   Code(owner: state.worker_ctx_name, runner: state.server_ctx_name, nim: nim)
 
 proc update_action_index*(state: GameState, change: int) =
-  var index = int(state.tool) + change
-  if index < 0:
-    index = int Tools.high
-  elif index > int Tools.high:
-    index = int Tools.low
+  # Cycle through the available tools only, skipping NONE/DISABLED and any tool
+  # the scripts have hidden.
+  let available = to_seq(CODE_MODE .. PLACE_BOT).filter_it(it in state.tools)
+  if available.len == 0:
+    return
 
-  state.tool = Tools(index)
+  var index = available.find(state.tool)
+  if index == -1:
+    # Not currently on an available tool (e.g. NONE) — step in from the edge.
+    index = if change >= 0: -1 else: 0
+  index = (index + change) mod available.len
+  if index < 0:
+    index += available.len
+
+  state.tool = available[index]
 
 proc require_lifetime*(unit: Unit): Lifetime =
   ## The Unit's owner Lifetime, created on demand. Locally built units get one in

--- a/src/game.nim
+++ b/src/game.nim
@@ -730,26 +730,27 @@ gdobj Game of Node:
     if state.tool != DISABLED:
       if event.is_action_pressed("toggle_code_mode"):
         if state.tool != CODE_MODE:
-          self.last_tool = state.tool
-          state.tool = CODE_MODE
+          if state.tool in state.tools:
+            self.last_tool = state.tool
+          state.select_tool CODE_MODE
         else:
-          state.tool = self.last_tool
+          state.select_tool self.last_tool
       elif event.is_action_pressed("mode_1"):
-        state.tool = CODE_MODE
+        state.select_tool CODE_MODE
       elif event.is_action_pressed("mode_2"):
-        state.tool = BLUE_BLOCK
+        state.select_tool BLUE_BLOCK
       elif event.is_action_pressed("mode_3"):
-        state.tool = RED_BLOCK
+        state.select_tool RED_BLOCK
       elif event.is_action_pressed("mode_4"):
-        state.tool = GREEN_BLOCK
+        state.select_tool GREEN_BLOCK
       elif event.is_action_pressed("mode_5"):
-        state.tool = BLACK_BLOCK
+        state.select_tool BLACK_BLOCK
       elif event.is_action_pressed("mode_6"):
-        state.tool = WHITE_BLOCK
+        state.select_tool WHITE_BLOCK
       elif event.is_action_pressed("mode_7"):
-        state.tool = BROWN_BLOCK
+        state.select_tool BROWN_BLOCK
       elif event.is_action_pressed("mode_8"):
-        state.tool = PLACE_BOT
+        state.select_tool PLACE_BOT
 
   method on_meta_clicked(url: string) =
     if url.starts_with("nim://"):

--- a/src/models/bots.nim
+++ b/src/models/bots.nim
@@ -81,7 +81,7 @@ method destroy*(self: Bot) =
 
 proc init*(
     _: type Bot,
-    id = "bot_" & generate_id() & "-" & Ed.thread_ctx.id,
+    id = "bot_" & generate_id(),
     transform = Transform.init,
     clone_of: Bot = nil,
     global = true,
@@ -113,7 +113,7 @@ proc init*(
     x, y, z: float,
     save = false,
     color = ACTION_COLORS[BLACK],
-    id = "bot_" & generate_id() & "-" & Ed.thread_ctx.id,
+    id = "bot_" & generate_id(),
 ): Bot =
   ## A bot at (x, y, z) for demos and external agents. EPHEMERAL by default —
   ## session-scoped: it survives reloads, is skipped by persistence, and is

--- a/src/models/builds.nim
+++ b/src/models/builds.nim
@@ -231,7 +231,7 @@ proc log_block_placement(self: Build, local: Vector3, color: Colors) =
     state.player.block_log_entries.del 0
 
 proc remove(self: Build) =
-  if state.tool notin {CODE_MODE, PLACE_BOT}:
+  if state.tool notin {Tools.NONE, CODE_MODE, PLACE_BOT}:
     state.skip_block_paint = true
     draw_normal = self.target_normal
     let point =
@@ -251,7 +251,7 @@ proc remove(self: Build) =
 
 proc fire(self: Build) =
   let global_point = self.target_point.global_from(self)
-  if state.tool notin {DISABLED, CODE_MODE, PLACE_BOT}:
+  if state.tool notin {DISABLED, Tools.NONE, CODE_MODE, PLACE_BOT}:
     state.skip_block_paint = true
     draw_normal = self.target_normal
     let point = (self.target_point + (self.target_normal * 0.5)).floor

--- a/src/models/builds.nim
+++ b/src/models/builds.nim
@@ -403,7 +403,7 @@ method destroy*(self: Build) =
 
 proc init*(
     _: type Build,
-    id = "build_" & generate_id() & "-" & Ed.thread_ctx.id,
+    id = "build_" & generate_id(),
     transform = Transform.init,
     color = default_color,
     clone_of: Unit = nil,

--- a/src/models/ground.nim
+++ b/src/models/ground.nim
@@ -6,7 +6,7 @@ var add_to {.threadvar.}: Build
 proc fire(self: Ground, append = false) {.gcsafe.} =
   state.draw_unit_id = "ground"
   let point = (self.target_point - vec3(0.5, 0, 0.5)).trunc
-  if state.tool notin {DISABLED, CODE_MODE, PLACE_BOT}:
+  if state.tool notin {DISABLED, Tools.NONE, CODE_MODE, PLACE_BOT}:
     if not append:
       # Check if we should stick to the last modified build (within 500ms)
       let now = get_mono_time()
@@ -50,7 +50,7 @@ proc init*(_: type Ground, node: Spatial): Ground =
 
   self.local_flags.changes:
     if PRIMARY_DOWN in state.local_flags and state.draw_unit_id == "ground":
-      if change.item == TARGET_MOVED and state.tool != PLACE_BOT:
+      if change.item == TARGET_MOVED and state.tool notin {PLACE_BOT, Tools.NONE}:
         self.fire(append = true)
 
   result = self

--- a/src/models/serializers.nim
+++ b/src/models/serializers.nim
@@ -17,6 +17,7 @@ type LevelInfo = object
   enu_version*, format_version*: string
   load_order*: seq[string]
   show_prototypes*: bool
+  show_tools*: bool
 
 proc from_json_hook*(self: var LevelInfo, json: JsonNode) =
   self.enu_version = json{"enu_version"}.get_str
@@ -31,6 +32,11 @@ proc from_json_hook*(self: var LevelInfo, json: JsonNode) =
     self.show_prototypes = json["show_prototypes"].get_bool
   else:
     self.show_prototypes = true
+
+  if "show_tools" in json:
+    self.show_tools = json["show_tools"].get_bool
+  else:
+    self.show_tools = true
 
 proc to_json_hook(self: Color): JsonNode =
   result =
@@ -478,6 +484,7 @@ proc save_level*(level_dir: string, save_all = false, force = false) =
       format_version: "v0.9.2",
       load_order: sorted_scripts,
       show_prototypes: state.show_prototypes,
+      show_tools: state.show_tools,
     )
     write_file_if_changed level_dir / "level.json",
       jsonutils.to_json(level).pretty
@@ -617,6 +624,7 @@ proc load_level*(worker: Worker, level_dir: string) =
   var load_order = newSeq[string]()
 
   state.show_prototypes = true
+  state.show_tools = true
   if file_exists(level_file):
     try:
       let level_json = read_file(level_file)
@@ -625,8 +633,17 @@ proc load_level*(worker: Worker, level_dir: string) =
       if level.load_order.len > 0:
         load_order = level.load_order
       state.show_prototypes = level.show_prototypes
+      state.show_tools = level.show_tools
     except Exception as e:
       error "Failed to load level", error = e
+
+  # Seed the available tools before scripts run and the player can interact:
+  # full set by default, empty when the level opts out (its script adds back
+  # what it needs). Happens inside LOADING_LEVEL so the toolbar snaps, no slide.
+  if state.show_tools:
+    state.tools.value = {CODE_MODE .. PLACE_BOT}
+  else:
+    state.tools.clear()
 
   worker.run_state_initializers()
 

--- a/src/models/states.nim
+++ b/src/models/states.nim
@@ -32,7 +32,9 @@ proc resolve_flags*(
           result.excl f
     result.incl flag
 
-  if self.tool == CODE_MODE:
+  # CODE_MODE and NONE (no tool) don't target blocks: hide the block target and
+  # keep the reticle up, like play mode.
+  if self.tool in {CODE_MODE, NONE}:
     for flag in groups[1]:
       result.excl(flag)
     result.incl(RETICLE_VISIBLE)

--- a/src/models/states.nim
+++ b/src/models/states.nim
@@ -168,6 +168,7 @@ proc init*(_: type GameState): GameState =
     tools: Ed.init({CODE_MODE .. PLACE_BOT}, flags = {SYNC_LOCAL, SYNC_REMOTE}),
     gravity: -80.0,
     show_prototypes: true,
+    show_tools: true,
     console: ConsoleModel(log: EdSeq[string].init(flags = flags)),
     open_sign_value: EdValue[Sign].init(flags = flags),
     wants: EdSeq[LocalStateFlags].init(flags = flags),

--- a/src/models/states.nim
+++ b/src/models/states.nim
@@ -132,6 +132,12 @@ proc `-=`*(
 proc selected_color*(self: GameState): Color =
   ACTION_COLORS[Colors(ord self.tool)]
 
+proc select_tool*(self: GameState, tool: Tools) =
+  ## Make `tool` active, but only when it's available. Selecting an
+  ## unavailable tool is a no-op so the player can't pick a hidden tool.
+  if tool in self.tools:
+    self.tool = tool
+
 proc init_logger*(self: GameState) =
   self.logger = proc(level, msg: string) {.closure.} =
     if level == "err" and state.config.auto_show_console:
@@ -157,6 +163,7 @@ proc init*(_: type GameState): GameState =
     open_unit_value: EdValue[Unit].init(flags = flags),
     config_value: EdValue[Config].init(flags = flags, id = "config"),
     tool_value: EdValue[Tools].init(BLUE_BLOCK, flags = flags),
+    tools: Ed.init({CODE_MODE .. PLACE_BOT}, flags = {SYNC_LOCAL, SYNC_REMOTE}),
     gravity: -80.0,
     show_prototypes: true,
     console: ConsoleModel(log: EdSeq[string].init(flags = flags)),
@@ -183,6 +190,12 @@ proc init*(_: type GameState): GameState =
     elif added:
       self.push_flag EDITOR_OPENING
       self.pop_flag EDITOR_VISIBLE
+
+  self.tools.changes:
+    # Lose the active tool when it's removed; stay in NONE until something is
+    # explicitly selected (no auto-recovery when tools come back).
+    if removed and change.item == self.tool:
+      self.tool = NONE
 
   self.local_flags.changes:
     if EDITOR_VISIBLE.added:

--- a/src/models/units.nim
+++ b/src/models/units.nim
@@ -63,6 +63,9 @@ proc init_unit*[T: Unit](self: T, shared = true) =
     rendered_voxel_count_value = ed(0)
     pending_block_updates_value = ed(0)
     query_value = EdValue[UnitQuery].init(UnitQuery())
+    # Stamp the creating context (init_unit only runs on the creating side;
+    # synced replicas are reconstructed via parse), synced remote+local.
+    owner_ctx_value = ed(Ed.thread_ctx.id)
 
   self.init_shared
   self.global_flags += VISIBLE

--- a/src/types.nim
+++ b/src/types.nim
@@ -195,6 +195,7 @@ type
     console*: ConsoleModel
     paused*: bool
     show_prototypes*: bool
+    show_tools*: bool # level.json: false starts with no tools (script adds them)
     frame_count*: int
     skip_block_paint*: bool
     disable_packed_chunks*: bool # Runtime toggle for packed chunk format

--- a/src/types.nim
+++ b/src/types.nim
@@ -165,6 +165,7 @@ type
     WHITE_BLOCK
     BROWN_BLOCK
     PLACE_BOT
+    NONE
     DISABLED
 
   TaskStates* = enum
@@ -182,6 +183,7 @@ type
     config_value*: EdValue[Config]
     open_unit_value*: EdValue[Unit]
     tool_value*: EdValue[Tools]
+    tools*: EdSet[Tools]
     gravity*: float
     nodes*: tuple[game: Node, data: Node, player: Node]
     screenshot_camera*: Node

--- a/src/types.nim
+++ b/src/types.nim
@@ -145,10 +145,8 @@ type
       ## units survive level reloads (peer to the human), are skipped
       ## by level persistence (their lifecycle is the client's, not
       ## the level's), and get cleaned up when their owning context
-      ## unsubscribes. Convention: agent unit ids contain the owning
-      ## context name as a substring (e.g. `player-{ctx_name}`,
-      ## `mcp_bot-{ctx_name}`) so worker.nim can match them on
-      ## unsubscribe.
+      ## unsubscribes — matched on the unit's `owner_ctx` (the ctx that
+      ## created it), which worker.nim reaps on unsubscribe.
     VOXEL_VIEWER
       ## The unit streams voxel terrain around itself: the server attaches
       ## a VoxelViewer node so chunks near the unit get meshed even when no
@@ -310,6 +308,9 @@ type
     rendered_voxel_count_value*: EdValue[int]
     pending_block_updates_value*: EdValue[int]
     query_value*: EdValue[UnitQuery]
+    owner_ctx_value*: EdValue[string]
+      # ctx id that created the unit, synced so the authority can reap EPHEMERAL
+      # units when that context drops -- without encoding the ctx in the id.
 
   BlockLogEntry* =
     tuple[

--- a/src/ui/toolbar.nim
+++ b/src/ui/toolbar.nim
@@ -1,4 +1,8 @@
-import godotapi/[h_box_container, scene_tree, button, image_texture]
+import
+  godotapi/[
+    h_box_container, scene_tree, scene_tree_tween, property_tweener,
+    method_tweener, tween, button, image_texture,
+  ]
 import pkg/[godot]
 import core
 import gdutils, ui/preview_maker
@@ -13,6 +17,9 @@ gdobj Toolbar of HBoxContainer:
     preview_result: Option[PreviewResult]
     waiting = false
     zid: EID
+    tween: SceneTreeTween
+    rest_y: float
+    rest_y_set: bool
 
   method ready*() =
     self.bind_signals self, "action_changed"
@@ -25,13 +32,66 @@ gdobj Toolbar of HBoxContainer:
         state.tool = DISABLED
       if PLAYING.removed:
         self.visible = true
-        state.tool = BLUE_BLOCK
+        state.tool = if BLUE_BLOCK in state.tools: BLUE_BLOCK else: NONE
 
     self.zid = state.tool_value.changes:
       if added:
-        let b = self.get_child(int(change.item)) as Button
+        self.show_pressed change.item
+
+    self.apply_visibility()
+    state.tools.changes:
+      self.animate_tools()
+
+  proc apply_visibility() =
+    for tool in CODE_MODE .. PLACE_BOT:
+      let b = self.get_child(int tool) as Button
+      if ?b:
+        b.visible = tool in state.tools
+
+  proc show_pressed(tool: Tools) =
+    if tool in {CODE_MODE .. PLACE_BOT}:
+      let b = self.get_child(int tool) as Button
+      if ?b:
+        b.set_pressed true
+    else:
+      # NONE / DISABLED: clear the selection so nothing looks active.
+      for t in CODE_MODE .. PLACE_BOT:
+        let b = self.get_child(int t) as Button
         if ?b:
-          b.set_pressed true
+          b.set_pressed false
+
+  method apply_tools*() {.gdexport.} =
+    # Runs at the bottom of the slide, while the toolbar is off-screen, so the
+    # button set changes out of sight.
+    self.apply_visibility()
+    self.show_pressed state.tool
+
+  proc animate_tools() =
+    # Slide the toolbar down and back up, swapping in the updated tool set at the
+    # bottom — matching the Settings slide-up look (vertical only).
+    if not self.rest_y_set:
+      self.rest_y = self.rect_position.y
+      self.rest_y_set = true
+    if ?self.tween:
+      self.tween.kill
+    self.rect_position = vec2(self.rect_position.x, self.rest_y)
+
+    let drop = self.rect_size.y + 10.0
+    self.tween = self.get_tree.create_tween()
+    discard self.tween
+      .tween_property(
+        self, "rect_position:y", (self.rest_y + drop).to_variant,
+        animation_duration,
+      )
+      .set_trans(TRANS_EXPO)
+      .set_ease(EASE_IN_OUT)
+    discard self.tween.tween_callback(self, "_apply_tools")
+    discard self.tween
+      .tween_property(
+        self, "rect_position:y", self.rest_y.to_variant, animation_duration
+      )
+      .set_trans(TRANS_EXPO)
+      .set_ease(EASE_IN_OUT)
 
   method process*(delta: float) =
     if self.preview_result.is_some:

--- a/src/ui/toolbar.nim
+++ b/src/ui/toolbar.nim
@@ -40,7 +40,12 @@ gdobj Toolbar of HBoxContainer:
 
     self.apply_visibility()
     state.tools.changes:
-      self.animate_tools()
+      # Level load seeds the tool set before the scene is interactive — snap to
+      # it instead of sliding, so a customized level doesn't open with a switch.
+      if LOADING_LEVEL in state.global_flags:
+        self.apply_tools()
+      else:
+        self.animate_tools()
 
   proc apply_visibility() =
     for tool in CODE_MODE .. PLACE_BOT:

--- a/tasks.nim
+++ b/tasks.nim
@@ -172,6 +172,7 @@ task test_unit, "run unit tests":
   exec "nim c -r tests/unit/script_ctx_test"
   exec "nim c -r tests/unit/serializers_test"
   exec "nim c -r tests/unit/dependency_graph_test"
+  exec "nim c -r tests/unit/tool_availability_test"
 
 task test_vm, "run VM script tests":
   exec "nim c -r tests/vm/runner"

--- a/tests/unit/tool_availability_test.nim
+++ b/tests/unit/tool_availability_test.nim
@@ -1,0 +1,55 @@
+import unittest2
+import core
+import models/states
+
+suite "Tool availability":
+  setup:
+    state = GameState.init
+
+  test "defaults to all real tools, blue active":
+    check state.tool == BLUE_BLOCK
+    for tool in CODE_MODE .. PLACE_BOT:
+      check tool in state.tools
+    check NONE notin state.tools
+    check DISABLED notin state.tools
+
+  test "removing the active tool drops to NONE":
+    state.tools -= BLUE_BLOCK
+    check state.tool == NONE
+
+  test "removing a non-active tool leaves the active tool alone":
+    state.tools -= RED_BLOCK
+    check state.tool == BLUE_BLOCK
+
+  test "selecting an unavailable tool is a no-op":
+    state.tools -= RED_BLOCK
+    state.select_tool RED_BLOCK
+    check state.tool == BLUE_BLOCK
+
+  test "selecting an available tool works":
+    state.select_tool GREEN_BLOCK
+    check state.tool == GREEN_BLOCK
+
+  test "removing every tool stays NONE with no auto-recovery":
+    state.tools.clear()
+    check state.tool == NONE
+    # a tool coming back does not auto-select it
+    state.tools += BLUE_BLOCK
+    check state.tool == NONE
+    # the player is unstuck only by an explicit selection
+    state.select_tool BLUE_BLOCK
+    check state.tool == BLUE_BLOCK
+
+  test "cycling skips unavailable tools and NONE/DISABLED":
+    state.tools -= RED_BLOCK
+    state.tools -= GREEN_BLOCK
+    state.tool = BLUE_BLOCK # red/green gone, next available is black
+    # removing the actives above could have dropped us to NONE; reset explicitly
+    state.update_action_index(1)
+    check state.tool == BLACK_BLOCK
+
+  test "cycling is a no-op when no tools are available":
+    state.tools.clear()
+    check state.tool == NONE
+    state.update_action_index(1)
+    check state.tool == NONE

--- a/tests/unit/tool_availability_test.nim
+++ b/tests/unit/tool_availability_test.nim
@@ -53,3 +53,10 @@ suite "Tool availability":
     check state.tool == NONE
     state.update_action_index(1)
     check state.tool == NONE
+
+  test "NONE hides the block target and keeps the reticle, like play mode":
+    state.tool = NONE
+    state.push_flag MOUSE_CAPTURED
+    state.push_flag BLOCK_TARGET_VISIBLE
+    check BLOCK_TARGET_VISIBLE notin state.local_flags
+    check RETICLE_VISIBLE in state.local_flags

--- a/tests/vm/runner.nim
+++ b/tests/vm/runner.nim
@@ -193,6 +193,34 @@ proc setup_mock_functions(interp: Interpreter) =
     "position_set_impl",
     proc(args: VmArgs) = discard
 
+  # Mock the available-tools set with a plain host-side set, ignoring `self`
+  # (the test uses a single global player). `tool` is arg 1.
+  var mock_tools {.global.}: set[uint8]
+  interp.implement_routine pkg,
+    "players",
+    "tools_has_impl",
+    proc(args: VmArgs) =
+      {.cast(gcsafe).}:
+        args.set_result(uint8(args.get_int(1)) in mock_tools)
+  interp.implement_routine pkg,
+    "players",
+    "tools_incl_impl",
+    proc(args: VmArgs) =
+      {.cast(gcsafe).}:
+        mock_tools.incl uint8(args.get_int(1))
+  interp.implement_routine pkg,
+    "players",
+    "tools_excl_impl",
+    proc(args: VmArgs) =
+      {.cast(gcsafe).}:
+        mock_tools.excl uint8(args.get_int(1))
+  interp.implement_routine pkg,
+    "players",
+    "tools_clear_impl",
+    proc(args: VmArgs) =
+      {.cast(gcsafe).}:
+        mock_tools = {}
+
 proc run_test_script(script_path: string): TestResult =
   result.name = script_path.extract_filename.change_file_ext("")
 

--- a/tests/vm/scripts/tool_set_test.nim
+++ b/tests/vm/scripts/tool_set_test.nim
@@ -1,0 +1,30 @@
+# Exercises the player.tools set-like surface and its host bridge.
+import types, players
+
+# `self` is ignored by the test mocks, so a nil player is fine here.
+var p: Player
+
+p.tools = {BlueBlock, CodeMode}
+assert CodeMode in p.tools
+assert BlueBlock in p.tools
+assert RedBlock notin p.tools
+assert p.tools.len == 2
+
+p.tools.incl RedBlock
+assert RedBlock in p.tools
+assert p.tools.len == 3
+
+p.tools.excl CodeMode
+assert CodeMode notin p.tools
+assert p.tools.len == 2
+
+var seen: seq[Tools]
+for tool in p.tools:
+  seen.add tool
+assert seen == @[BlueBlock, RedBlock]
+
+p.tools.clear()
+assert p.tools.len == 0
+assert BlueBlock notin p.tools
+
+echo "  [VM] tool set tests passed!"

--- a/vmlib/enu/players.nim
+++ b/vmlib/enu/players.nim
@@ -3,6 +3,10 @@ import types, base_api, vm_bridge_utils, builds_private
 bridged_to_host:
   proc tool*(self: Player): Tools
   proc `tool=`*(self: Player, value: Tools)
+  proc tools_has*(self: Player, tool: Tools): bool
+  proc tools_incl*(self: Player, tool: Tools)
+  proc tools_excl*(self: Player, tool: Tools)
+  proc tools_clear*(self: Player)
   proc playing*(self: Player): bool
   proc `playing=`*(self: Player, value: bool)
   proc flying*(self: Player): bool
@@ -34,3 +38,47 @@ proc number*(self: Player): int =
       return i + 1
 
   raise newException(ValueError, "Player not found in player list")
+
+type ToolSet* = distinct Player
+  ## Set-like view over a player's available tools. Operations forward to the
+  ## host one tool at a time, so no real set crosses the bridge.
+
+proc tools*(self: Player): ToolSet =
+  ToolSet(self)
+
+proc contains*(tools: ToolSet, tool: Tools): bool =
+  Player(tools).tools_has(tool)
+
+proc incl*(tools: ToolSet, tool: Tools) =
+  Player(tools).tools_incl(tool)
+
+proc excl*(tools: ToolSet, tool: Tools) =
+  Player(tools).tools_excl(tool)
+
+proc clear*(tools: ToolSet) =
+  Player(tools).tools_clear()
+
+iterator items*(tools: ToolSet): Tools =
+  for tool in CodeMode .. PlaceBot:
+    if tool in tools:
+      yield tool
+
+proc len*(tools: ToolSet): int =
+  for _ in tools:
+    inc result
+
+proc `$`*(tools: ToolSet): string =
+  result = "{"
+  for tool in tools:
+    if result.len > 1:
+      result &= ", "
+    result &= $tool
+  result &= "}"
+
+proc `tools=`*(self: Player, value: set[Tools]) =
+  ## Replace the available tools with `value` (a normal VM set literal, iterated
+  ## here — never marshalled). `None` is ignored; it isn't a selectable tool.
+  self.tools_clear()
+  for tool in value:
+    if tool != None:
+      self.tools_incl(tool)

--- a/vmlib/enu/types.nim
+++ b/vmlib/enu/types.nim
@@ -84,6 +84,7 @@ type
     WhiteBlock
     BrownBlock
     PlaceBot
+    None
 
 proc vec3*(x, y, z: float): Vector3 {.inline.} =
   (x: x, y: y, z: z)


### PR DESCRIPTION
## What

Adds a way for scripts to control which tools the player can use, mirroring the existing active-tool API.

### Script API
`player.tools` is a set-like view over the player's available tools (a `SYNC_LOCAL + SYNC_REMOTE` `EdSet[Tools]`):

```nim
player.tools = {CodeMode, BlueBlock}   # bulk set (literal stays in the VM)
CodeMode in player.tools               # membership
player.tools.incl RedBlock             # toggle on
player.tools.excl CodeMode             # toggle off
for t in player.tools: ...             # iterate
```

It's a `ToolSet = distinct Player` backed by four bridged per-tool procs (`tools_has/incl/excl/clear`) — no set is marshalled across the VM↔host bridge.

### NONE state
- A new `NONE` active-tool state (inserted before `DISABLED` in both `Tools` enums, ordinals kept aligned for the bridge).
- Removing the active tool drops the player to `NONE`.
- Removing every tool leaves the player stuck in `NONE` until a tool is explicitly reselected (no auto-recovery).
- Key/scroll selection and tool cycling skip unavailable tools and `NONE`/`DISABLED`.

### Toolbar
On a tools change the toolbar slides down, swaps the visible button set off-screen, and slides back up — vertical only, matching the Settings slide-up look (`create_tween` + `TRANS_EXPO`/`EASE_IN_OUT`). Multiple updates in one tick coalesce into a single animation that lands on the final state.

## Tests
- `tests/unit/tool_availability_test.nim` — NONE drop, no auto-recovery, gated selection, availability-aware cycling.
- `tests/vm/scripts/tool_set_test.nim` — exercises the `ToolSet` surface end-to-end through the bridge.

`nim test` (unit + VM) passes; host `nim build` passes.

## Follow-up (not in this PR)
A general "expose an Ed object/collection to the VM" mechanism (generalizing the unit-handle registry) would remove the per-element bridge boilerplate used here.