### PR TITLE
fix(voxels): paint the first ASAP buffer immediately

### DIFF
--- a/src/models/voxels.nim
+++ b/src/models/voxels.nim
@@ -964,7 +964,10 @@ proc begin_asap*(self: VoxelRenderer) =
   self.buffer_size = vec3()
   self.dirty = false
   self.asap_active = true
-  self.last_paste_time = get_mono_time()
+  # Backdate so the first dirty buffer paints on the next tick instead of
+  # waiting a full interval — the initial draw shows immediately, then
+  # sustained drawing batches at ASAP_PASTE_INTERVAL.
+  self.last_paste_time = get_mono_time() - ASAP_PASTE_INTERVAL
 
 proc tick*(self: VoxelRenderer, is_local: bool) =
   ## Periodic paste for local ASAP mode only (visual progress feedback).


### PR DESCRIPTION
## Problem

Voxels from a script take ~1–2s to appear, even for a single block (e.g. `up 1`). The toolbar's ~0.6s animation finishes well before the build shows up.

## Cause

Builds default to ASAP mode. A scripted `draw` buffers the voxel into an off-screen `VoxelBuffer` (`buffer_delta`/`buffer_snapshot` set `dirty = true`) but the buffer is only pasted to the **visible** `voxel_tool` in `VoxelRenderer.tick`, gated by `ASAP_PASTE_INTERVAL` = `init_duration(seconds = 2)`. `begin_asap` set `last_paste_time = now`, so when a build (re)enters ASAP around play, the first draw waits up to a full interval (~2s) to paint — the data is buffered instantly, only the local visual paste is throttled.

## Fix

Backdate `last_paste_time` by one interval in `begin_asap`, so the first dirty buffer paints on the very next tick. Sustained drawing still batches at the 2s cadence (the throttle resumes after the first paste). One-line change in `src/models/voxels.nim`.

`nim build` and `nim test` pass. Unrelated to the tool-availability work (#67).