### PR TITLE
fix(bot): honor start_color

### DIFF
--- a/src/models/bots.nim
+++ b/src/models/bots.nim
@@ -90,6 +90,7 @@ proc init*(
     clone_of: Bot = nil,
     global = true,
     parent: Unit = nil,
+    color = ACTION_COLORS[BLACK],
 ): Bot =
   ## The level-bot initializer enu uses internally (placed, loaded, cloned):
   ## the bot belongs to the level and persists with it. Demos and external
@@ -101,7 +102,7 @@ proc init*(
       start_transform: transform,
       animation_value: ed("auto"),
       clone_of: clone_of,
-      start_color: ACTION_COLORS[BLACK],
+      start_color: color,
       parent: parent,
     )
 
@@ -122,20 +123,20 @@ proc init*(
   ## A bot at (x, y, z) for demos and external agents. EPHEMERAL by default —
   ## session-scoped: it survives reloads, is skipped by persistence, and is
   ## reaped when the session ends. Pass `save = true` to keep it in the level.
-  result = Bot.init(id = id, transform = Transform.init(vec3(x, y, z)))
-  result.color = color
+  result =
+    Bot.init(id = id, transform = Transform.init(vec3(x, y, z)), color = color)
   if not save:
     result.global_flags += EPHEMERAL
 
 method clone*(self: Bot, clone_to: Unit, id: string): Unit =
   var transform = clone_to.transform
-  result =
-    Bot.init(
-      id = id,
-      transform = transform,
-      clone_of = self,
-      parent = clone_to,
-    )
+  result = Bot.init(
+    id = id,
+    transform = transform,
+    clone_of = self,
+    parent = clone_to,
+    color = self.start_color,
+  )
 
 method on_collision*(self: Unit, partner: Model, normal: Vector3) =
   self.collisions.add (partner.id, normal)

--- a/src/models/serializers.nim
+++ b/src/models/serializers.nim
@@ -132,9 +132,17 @@ proc from_json_hook(self: var Build, json: JsonNode) =
     self.voxels.rebuild_local_edits()
 
 proc from_json_hook(self: var Bot, json: JsonNode) =
+  # `start_color` is always written (the shared unit serializer), but tolerate
+  # hand-authored or ancient files that lack it.
+  let color =
+    if "start_color" in json:
+      json["start_color"].json_to(Color)
+    else:
+      ACTION_COLORS[BLACK]
   self = Bot.init(
     id = json["id"].json_to(string),
     transform = json["start_transform"].json_to(Transform),
+    color = color,
   )
 
   if not load_chunks and "edits" in json:


### PR DESCRIPTION
Loaded bots were always black: the bot `from_json_hook` never read `start_color` from the JSON (the shared unit writer always emits it — Build's hook reads it, Bot's dropped it), and `Bot.init` hardcoded black.

- `Bot.init` takes a `color` param (sets `start_color`; `init_unit` already derives the live color from it).
- The bot JSON hook passes the saved color through, tolerating hand-authored files without the key.
- The `(x, y, z)` agent overload routes its color the same way.
- `Bot.clone` passes the prototype's `start_color`, so instances match their proto (parity with `Build.clone`).

Verified live in MCP: a bot saved with `"start_color": "RED"` loads and renders red (screenshot-confirmed), and the save/load round-trip preserves it. Placing a colored bot in-game remains out of scope — `selected_color` is derived from the active tool, so there's no color selection while the bot tool is active.

Fast + world tests green.