### PR TITLE
Restore CI on all platforms + wire Windows release-signing

### DIFF
--- a/.github/workflows/dist_linux.yaml
+++ b/.github/workflows/dist_linux.yaml
@@ -16,14 +16,14 @@ jobs:
       - name: Install Nim
         run: |
           cd $HOME &&
-          curl -O https://nim-lang.org/download/nim-2.2.6-linux_x64.tar.xz &&
-          tar xf nim-2.2.6-linux_x64.tar.xz
+          curl -O https://nim-lang.org/download/nim-2.2.10-linux_x64.tar.xz &&
+          tar xf nim-2.2.10-linux_x64.tar.xz
       - name: Install build deps
         run: |
           sudo apt-get update
           sudo apt-get install build-essential scons pkg-config libx11-dev libxcursor-dev libxinerama-dev libgl1-mesa-dev libglu-dev libasound2-dev libpulse-dev libudev-dev libxi-dev libxrandr-dev libfuse2
       - name: Update path
-        run: echo "$HOME/nim-2.2.6/bin" >> $GITHUB_PATH
+        run: echo "$HOME/nim-2.2.10/bin" >> $GITHUB_PATH
       - name: Save SHAs of submodules
         run: 'git submodule status > .submodules.tmp'
       - name: Prep dist config

--- a/.github/workflows/dist_mac.yaml
+++ b/.github/workflows/dist_mac.yaml
@@ -13,45 +13,53 @@ jobs:
         uses: actions/checkout@v3
         with:
           fetch-depth: 0
-      - name: Install certificates. Write dist_config.json.
-        env:
-          DIST_CONFIG: ${{ secrets.PROD_MACOS_DIST_CONFIG }}
-          CERTIFICATE: ${{ secrets.PROD_MACOS_CERTIFICATE }}
-          CERTIFICATE_PWD: ${{ secrets.PROD_MACOS_CERTIFICATE_PWD }}
-          CERTIFICATE_NAME: ${{ secrets.PROD_MACOS_CERTIFICATE_NAME }}
-          KEYCHAIN_PWD: ${{ secrets.PROD_MACOS_CI_KEYCHAIN_PWD }}
-          NOTARIZATION_APPLE_ID: ${{ secrets.PROD_MACOS_NOTARIZATION_APPLE_ID }}
-          NOTARIZATION_TEAM_ID: ${{ secrets.PROD_MACOS_NOTARIZATION_TEAM_ID }}
-          NOTARIZATION_PWD: ${{ secrets.PROD_MACOS_NOTARIZATION_PWD }}
-          NOTARIZATION_PROFILE: ${{ secrets.PROD_MACOS_NOTARIZATION_PROFILE }}
-        run: |
-          # Adapted from https://federicoterzi.com/blog/automatic-code-signing-and-notarization-for-macos-apps-using-github-actions/
+      # TEMPORARY: signing + notarization disabled while the Apple developer
+      # account is expired. Restore the "Install certificates" step below (and
+      # remove the "Prep dist config" step) once the account is renewed. The
+      # example config sets sign=false/notarize=false, so `nim dist_package`
+      # produces an unsigned .dmg. Nothing here has been removed on purpose.
+      - name: Prep dist config (unsigned — Apple account expired)
+        run: cp dist_config.example.json dist_config.json
 
-          # Turn our base64-encoded certificate back to a regular .p12 file
-
-          echo $CERTIFICATE | base64 --decode > certificate.p12
-          echo $DIST_CONFIG | base64 --decode > dist_config.json
-
-          # We need to create a new keychain, otherwise using the certificate will prompt
-          # with a UI dialog asking for the certificate password, which we can't
-          # use in a headless CI environment
-
-          security create-keychain -p "$KEYCHAIN_PWD" build.keychain
-          security default-keychain -s build.keychain
-          security unlock-keychain -p "$KEYCHAIN_PWD" build.keychain
-          security import certificate.p12 -k build.keychain -P "$CERTIFICATE_PWD" -T /usr/bin/codesign
-          security set-key-partition-list -S apple-tool:,apple:,codesign: -s -k "$KEYCHAIN_PWD" build.keychain
-
-          echo "Create keychain profile"
-          xcrun notarytool store-credentials "$NOTARIZATION_PROFILE" --apple-id "$NOTARIZATION_APPLE_ID" --team-id "$NOTARIZATION_TEAM_ID" --password "$NOTARIZATION_PWD"
+      # - name: Install certificates. Write dist_config.json.
+      #   env:
+      #     DIST_CONFIG: ${{ secrets.PROD_MACOS_DIST_CONFIG }}
+      #     CERTIFICATE: ${{ secrets.PROD_MACOS_CERTIFICATE }}
+      #     CERTIFICATE_PWD: ${{ secrets.PROD_MACOS_CERTIFICATE_PWD }}
+      #     CERTIFICATE_NAME: ${{ secrets.PROD_MACOS_CERTIFICATE_NAME }}
+      #     KEYCHAIN_PWD: ${{ secrets.PROD_MACOS_CI_KEYCHAIN_PWD }}
+      #     NOTARIZATION_APPLE_ID: ${{ secrets.PROD_MACOS_NOTARIZATION_APPLE_ID }}
+      #     NOTARIZATION_TEAM_ID: ${{ secrets.PROD_MACOS_NOTARIZATION_TEAM_ID }}
+      #     NOTARIZATION_PWD: ${{ secrets.PROD_MACOS_NOTARIZATION_PWD }}
+      #     NOTARIZATION_PROFILE: ${{ secrets.PROD_MACOS_NOTARIZATION_PROFILE }}
+      #   run: |
+      #     # Adapted from https://federicoterzi.com/blog/automatic-code-signing-and-notarization-for-macos-apps-using-github-actions/
+      #
+      #     # Turn our base64-encoded certificate back to a regular .p12 file
+      #
+      #     echo $CERTIFICATE | base64 --decode > certificate.p12
+      #     echo $DIST_CONFIG | base64 --decode > dist_config.json
+      #
+      #     # We need to create a new keychain, otherwise using the certificate will prompt
+      #     # with a UI dialog asking for the certificate password, which we can't
+      #     # use in a headless CI environment
+      #
+      #     security create-keychain -p "$KEYCHAIN_PWD" build.keychain
+      #     security default-keychain -s build.keychain
+      #     security unlock-keychain -p "$KEYCHAIN_PWD" build.keychain
+      #     security import certificate.p12 -k build.keychain -P "$CERTIFICATE_PWD" -T /usr/bin/codesign
+      #     security set-key-partition-list -S apple-tool:,apple:,codesign: -s -k "$KEYCHAIN_PWD" build.keychain
+      #
+      #     echo "Create keychain profile"
+      #     xcrun notarytool store-credentials "$NOTARIZATION_PROFILE" --apple-id "$NOTARIZATION_APPLE_ID" --team-id "$NOTARIZATION_TEAM_ID" --password "$NOTARIZATION_PWD"
 
       - name: Install build deps
         run: brew install scons yasm
       - name: Install nim
         run: |
-          curl -LO https://github.com/nim-lang/nightlies/releases/download/2025-10-31-version-2-2-ab00c56904e3126ad826bb520d243513a139436a/nim-2.2.6-macosx_arm64.tar.xz
-          tar xzf nim-2.2.6-macosx_arm64.tar.xz
-          echo "$(pwd)/nim-2.2.6/bin" >> $GITHUB_PATH
+          curl -LO https://github.com/nim-lang/nightlies/releases/download/2026-04-24-version-2-2-bfeb3146d1638b39f69007a4ae5a23e23ae4e5ef/nim-2.2.10-macosx_arm64.tar.xz
+          tar xzf nim-2.2.10-macosx_arm64.tar.xz
+          echo "$(pwd)/nim-2.2.10/bin" >> $GITHUB_PATH
       - name: Save SHAs of submodules
         run: "git submodule status > .submodules.tmp"
       - name: prereq cache

--- a/.github/workflows/dist_win.yaml
+++ b/.github/workflows/dist_win.yaml
@@ -17,14 +17,14 @@ jobs:
       - name: Install Nim
         run: |
           cd ${HOME}
-          C:\msys64\usr\bin\wget.exe https://nim-lang.org/download/nim-2.2.6_x64.zip
-          7z.exe x nim-2.2.6_x64.zip -y
+          C:\msys64\usr\bin\wget.exe https://nim-lang.org/download/nim-2.2.10_x64.zip
+          7z.exe x nim-2.2.10_x64.zip -y
       - name: Install build deps
         run: choco install yasm innosetup rcedit zip reshack
       - name: Install scons
         run: python -m pip install scons
       - name: Update path
-        run: echo "${HOME}/nim-2.2.6/bin;C:\msys64\mingw64\bin;C:\Program Files (x86)\Resource Hacker" | Out-File -FilePath $env:GITHUB_PATH -Encoding utf8 -Append
+        run: echo "${HOME}/nim-2.2.10/bin;C:\msys64\mingw64\bin;C:\Program Files (x86)\Resource Hacker" | Out-File -FilePath $env:GITHUB_PATH -Encoding utf8 -Append
       - name: Configure git
         run: |
           git config --global core.autocrlf false

--- a/.github/workflows/dist_win.yaml
+++ b/.github/workflows/dist_win.yaml
@@ -87,7 +87,11 @@ jobs:
           api-token: ${{ secrets.SIGNPATH_API_TOKEN }}
           organization-id: ${{ secrets.SIGNPATH_ORGANIZATION_ID }}
           project-slug: ${{ secrets.SIGNPATH_PROJECT_SLUG }}
-          signing-policy-slug: ${{ secrets.SIGNPATH_SIGNING_POLICY_SLUG }}
+          # Tags (v*) sign with the real SignPath Foundation cert via the
+          # release-signing policy (requires an approver to sign off in the
+          # SignPath UI). Every other push uses the auto-approved test cert so
+          # normal CI stays unattended and green.
+          signing-policy-slug: ${{ startsWith(github.ref, 'refs/tags/v') && 'release-signing' || 'test-signing' }}
           artifact-configuration-slug: enu-zip
           github-artifact-id: ${{ steps.upload-unsigned-zip.outputs.artifact-id }}
           wait-for-completion: true
@@ -124,7 +128,11 @@ jobs:
           api-token: ${{ secrets.SIGNPATH_API_TOKEN }}
           organization-id: ${{ secrets.SIGNPATH_ORGANIZATION_ID }}
           project-slug: ${{ secrets.SIGNPATH_PROJECT_SLUG }}
-          signing-policy-slug: ${{ secrets.SIGNPATH_SIGNING_POLICY_SLUG }}
+          # Tags (v*) sign with the real SignPath Foundation cert via the
+          # release-signing policy (requires an approver to sign off in the
+          # SignPath UI). Every other push uses the auto-approved test cert so
+          # normal CI stays unattended and green.
+          signing-policy-slug: ${{ startsWith(github.ref, 'refs/tags/v') && 'release-signing' || 'test-signing' }}
           artifact-configuration-slug: enu-installer
           github-artifact-id: ${{ steps.upload-unsigned-installer.outputs.artifact-id }}
           wait-for-completion: true

--- a/.github/workflows/dist_win.yaml
+++ b/.github/workflows/dist_win.yaml
@@ -95,6 +95,10 @@ jobs:
           artifact-configuration-slug: enu-zip
           github-artifact-id: ${{ steps.upload-unsigned-zip.outputs.artifact-id }}
           wait-for-completion: true
+          # Give the human approver a comfortable window (default is 600s / 10
+          # min). A release approval shouldn't race a short clock, especially
+          # since the tag build takes ~30 min to reach this point.
+          wait-for-completion-timeout-in-seconds: 1800
           output-artifact-directory: dist-signed-zip
 
       # Extract signed exe/dll from the signed zip
@@ -136,6 +140,10 @@ jobs:
           artifact-configuration-slug: enu-installer
           github-artifact-id: ${{ steps.upload-unsigned-installer.outputs.artifact-id }}
           wait-for-completion: true
+          # Give the human approver a comfortable window (default is 600s / 10
+          # min). A release approval shouldn't race a short clock, especially
+          # since the tag build takes ~30 min to reach this point.
+          wait-for-completion-timeout-in-seconds: 1800
           output-artifact-directory: dist-signed-installer
 
       # Upload final signed artifacts

--- a/.github/workflows/dist_win.yaml
+++ b/.github/workflows/dist_win.yaml
@@ -98,7 +98,7 @@ jobs:
           # Give the human approver a comfortable window (default is 600s / 10
           # min). A release approval shouldn't race a short clock, especially
           # since the tag build takes ~30 min to reach this point.
-          wait-for-completion-timeout-in-seconds: 1800
+          wait-for-completion-timeout-in-seconds: 3600
           output-artifact-directory: dist-signed-zip
 
       # Extract signed exe/dll from the signed zip
@@ -143,7 +143,7 @@ jobs:
           # Give the human approver a comfortable window (default is 600s / 10
           # min). A release approval shouldn't race a short clock, especially
           # since the tag build takes ~30 min to reach this point.
-          wait-for-completion-timeout-in-seconds: 1800
+          wait-for-completion-timeout-in-seconds: 3600
           output-artifact-directory: dist-signed-installer
 
       # Upload final signed artifacts

--- a/src/game.nim
+++ b/src/game.nim
@@ -17,6 +17,12 @@ import
   core, types, gdutils, controllers, models/[serializers, units, colors, builds]
 import libs/fd_tracking
 
+# Immediate process exit that runs no atexit handlers, C++ destructors, or Nim
+# GC teardown. Used to end test-mode runs without triggering Godot's headless
+# teardown (which segfaults) or Nim's `quit` (which re-enters ed's locks while
+# we're inside a flag-change callback, aborting on a recursive mutex).
+proc c_exit(code: cint) {.importc: "_Exit", header: "<stdlib.h>".}
+
 if file_exists(".env"):
   dotenv.overload()
 
@@ -564,6 +570,18 @@ gdobj Game of Node:
             state.test_exit_code
           else:
             0
+        if TEST_MODE in state.local_flags:
+          # Headless Godot's dummy rasterizer segfaults during teardown,
+          # freeing render resources it never allocated (NULL RID frees in
+          # visual_server_raster). The tests have already finished and their
+          # exit code is known, so exit the process directly rather than
+          # letting Godot's shutdown crash and mask the result. --temp-workdir
+          # means there's nothing to persist. We're inside a flag-change
+          # callback holding ed's lock, so we can't use Nim's `quit` (its
+          # teardown re-enters the lock); c_exit terminates with no cleanup.
+          flush_file stdout
+          flush_file stderr
+          c_exit(exit_code.cint)
         self.get_tree().quit(exit_code)
 
       if NEEDS_RESTART.removed:

--- a/src/libs/fd_tracking.nim
+++ b/src/libs/fd_tracking.nim
@@ -9,38 +9,52 @@
 ## startup. open_fd_count walks /dev/fd so we can watch the actual
 ## usage over time.
 
-import std/[os, posix]
+import std/os
 import pkg/metrics
 import chronicles
 
+when not defined(windows):
+  import std/posix
+
 declare_gauge enu_open_fds, "Open file descriptors held by the Enu process."
 
-proc raise_fd_limit*() =
-  ## Set RLIMIT_NOFILE soft limit to the hard limit (or 8192, whichever
-  ## is smaller). Logs the before/after for diagnosis.
-  var lim: RLimit
-  if getrlimit(RLIMIT_NOFILE, lim) != 0:
-    error "getrlimit failed", errno = errno
-    return
-  let before = lim.rlim_cur
-  let target = min(8192, lim.rlim_max)
-  if lim.rlim_cur >= target:
-    info "fd limit already at target", soft = before, hard = lim.rlim_max
-    return
-  lim.rlim_cur = target
-  if setrlimit(RLIMIT_NOFILE, lim) != 0:
-    error "setrlimit failed", errno = errno, target = target
-    return
-  info "raised fd limit", before, after = lim.rlim_cur, hard = lim.rlim_max
+when defined(windows):
+  proc raise_fd_limit*() =
+    ## No-op on Windows — there's no RLIMIT_NOFILE equivalent, and the CRT
+    ## fd limit is high enough that the reload-cycle EMFILE this guards
+    ## against on macOS doesn't apply.
+    discard
 
-proc open_fd_count*(): int =
-  ## Count entries in /dev/fd (macOS/Linux). Returns -1 if unavailable.
-  ## The directory handle we open is counted, so the result is one
-  ## higher than the steady-state count.
-  if not dir_exists("/dev/fd"):
-    return -1
-  for _, _ in walk_dir("/dev/fd"):
-    inc result
+  proc open_fd_count*(): int =
+    ## Unavailable on Windows (no /dev/fd).
+    -1
+else:
+  proc raise_fd_limit*() =
+    ## Set RLIMIT_NOFILE soft limit to the hard limit (or 8192, whichever
+    ## is smaller). Logs the before/after for diagnosis.
+    var lim: RLimit
+    if getrlimit(RLIMIT_NOFILE, lim) != 0:
+      error "getrlimit failed", errno = errno
+      return
+    let before = lim.rlim_cur
+    let target = min(8192, lim.rlim_max)
+    if lim.rlim_cur >= target:
+      info "fd limit already at target", soft = before, hard = lim.rlim_max
+      return
+    lim.rlim_cur = target
+    if setrlimit(RLIMIT_NOFILE, lim) != 0:
+      error "setrlimit failed", errno = errno, target = target
+      return
+    info "raised fd limit", before, after = lim.rlim_cur, hard = lim.rlim_max
+
+  proc open_fd_count*(): int =
+    ## Count entries in /dev/fd (macOS/Linux). Returns -1 if unavailable.
+    ## The directory handle we open is counted, so the result is one
+    ## higher than the steady-state count.
+    if not dir_exists("/dev/fd"):
+      return -1
+    for _, _ in walk_dir("/dev/fd"):
+      inc result
 
 proc sample_open_fds*() =
   ## Update the enu_open_fds gauge from /dev/fd. Cheap; safe to call


### PR DESCRIPTION
## Restore CI on all three platforms + wire Windows release-signing

CI had been red on `main`/`adopt` for a while. This gets **Linux, macOS, and Windows** dist builds green again and sets up the Windows 0.3 release to be signed with the real cert.

### CI fixes
- **Nim 2.2.6 → 2.2.10** (all three workflows). Host Nim 2.2.6 lacks `nimCStrLen`, which `deps/nim`'s compiler source requires when compiling `tools/build_helpers` — this broke Linux and Windows at prereqs. (macOS uses the `2026-04-24` nightly that ships `nim-2.2.10-macosx_arm64`.)
- **`fd_tracking.nim` guarded for Windows.** It uses `std/posix` `getrlimit`/`setrlimit` and `/dev/fd`, which don't exist on Windows and failed the gcc compile. Windows now gets no-op `raise_fd_limit` / `open_fd_count` → `-1`; the fd-exhaustion issue it guards is macOS-specific.
- **Headless world-test teardown fix.** Headless Godot's dummy rasterizer segfaults during shutdown (NULL RID frees in `visual_server_raster`), failing `nim test_world headless` even though the tests passed (`exit_code=0`). In test mode we now exit the process via `_Exit` once tests finish, bypassing Godot's crashy teardown. Nim's `quit` can't be used there — we're inside an ed flag-change callback holding a recursive mutex, and `quit`'s GC teardown re-enters it and aborts. The dist build (real rasterizer) tears down cleanly, so only headless was affected.

### macOS signing — temporarily disabled
The Apple developer account agreement has expired (notarytool returns 403). The "Install certificates" step is **commented out, not removed** (clearly marked to restore on renewal), and the job now writes `dist_config.example.json` (`sign=false`/`notarize=false`/`package=true`) so it still produces an unsigned `.dmg`. **Revert this once the Apple account is renewed.**

### Windows release-signing
- Tag-gated policy selection: `v*` tags sign with the real SignPath Foundation cert (`release-signing`, requires an approver); every other push uses the auto-approved `test-signing` cert so normal CI stays unattended.
- Approval window raised to 60 min (`wait-for-completion-timeout-in-seconds`), since a tag build takes ~30 min to reach the signing step and a release approval shouldn't race a 10-minute clock.

### Testing
- All three dist builds verified green on this branch (build + unit + VM tests; Linux world tests; Windows test-signing pipeline).
- The `_Exit` change was verified locally (`nim test_world`: both levels pass, exit 0, no mutex abort).
- The **release-signing path was exercised end-to-end** via a tag dry-run: tag → `release-signing` → submitter privilege → approve → sign with Foundation cert → download → rebuild installer → sign installer → publish signed `.zip` + installer.

### Notes / follow-ups
- Restore the macOS signing step when the Apple account renews.
- The `SIGNPATH_SIGNING_POLICY_SLUG` secret is now unused (policy is computed per-ref in the workflow); harmless to leave.
- SignPath release approvals lag 1–3 min after clicking, due to the action's polling back-off — expected, don't re-approve. Approve the **newest** request when multiple are queued.
