### PR TITLE
Show a Logo-style turtle while editing a build

### DIFF
--- a/app/components/TurtleOverlay.gdns
+++ b/app/components/TurtleOverlay.gdns
@@ -1,0 +1,8 @@
+[gd_resource type="NativeScript" load_steps=2 format=2]
+
+[ext_resource path="res://nimlib.gdnlib" type="GDNativeLibrary" id=1]
+
+[resource]
+resource_name = "TurtleOverlay"
+class_name = "TurtleOverlay"
+library = ExtResource( 1 )

--- a/app/scenes/game.tscn
+++ b/app/scenes/game.tscn
@@ -1,8 +1,9 @@
-[gd_scene load_steps=4 format=2]
+[gd_scene load_steps=5 format=2]
 
 [ext_resource path="res://scenes/world.tscn" type="PackedScene" id=1]
 [ext_resource path="res://components/Game.gdns" type="Script" id=2]
 [ext_resource path="res://scenes/GUI.tscn" type="PackedScene" id=3]
+[ext_resource path="res://components/TurtleOverlay.gdns" type="Script" id=4]
 
 [node name="Game" type="Spatial"]
 script = ExtResource( 2 )
@@ -21,6 +22,13 @@ render_target_update_mode = 3
 shadow_atlas_size = 100
 
 [node name="Level" parent="ViewportContainer/Viewport" instance=ExtResource( 1 )]
+
+[node name="TurtleOverlay" type="ViewportContainer" parent="."]
+anchor_right = 1.0
+anchor_bottom = 1.0
+mouse_filter = 2
+stretch = true
+script = ExtResource( 4 )
 
 [node name="GUI" parent="." instance=ExtResource( 3 )]
 

--- a/src/controllers/script_controllers/host_bridge.nim
+++ b/src/controllers/script_controllers/host_bridge.nim
@@ -741,6 +741,7 @@ proc advance(self: Build, steps: float) =
   ## animation or risking the speed-toggle render race.
   let offset = self.draw_transform.basis.xform(FORWARD) * steps
   self.draw_transform_value.origin = self.draw_transform.origin + offset
+  self.sync_turtle()
 
 proc draw_position_set(self: Build, position: Vector3) =
   if GLOBAL in self.global_flags:
@@ -748,6 +749,7 @@ proc draw_position_set(self: Build, position: Vector3) =
   else:
     self.draw_transform_value.origin =
       (position - self.position).local_to(self.parent)
+  self.sync_turtle()
 
 proc save(self: Build, name: string) =
   self.save_points[name] =
@@ -761,6 +763,7 @@ proc restore(self: Build, name: string) =
     # compiles but silently writes into the getters' temporaries.
     let (position, color, drawing) = self.save_points[name]
     self.draw_transform = position
+    self.sync_turtle()
     self.color_value.value = color
     self.drawing = drawing
 

--- a/src/enu.nim
+++ b/src/enu.nim
@@ -10,7 +10,7 @@ import
 import
   nodes/[
     player_node, aim_target, selection_area, bot_node, ground_node, build_node,
-    sign_node,
+    sign_node, turtle_overlay,
   ]
 
 Ed.bootstrap

--- a/src/models/builds.nim
+++ b/src/models/builds.nim
@@ -203,6 +203,12 @@ proc draw*(self: Build, position: Vector3, voxel: VoxelInfo) {.gcsafe.} =
   if not dont_join and voxel.kind == MANUAL:
     self.maybe_join_previous_build(position, voxel)
 
+proc sync_turtle*(self: Build) =
+  # Mirror draw_transform for the render side. Called once per batch of
+  # draw_transform writes, not per voxel — see turtle_transform in types.nim.
+  if self.turtle_transform != self.draw_transform:
+    self.turtle_transform = self.draw_transform
+
 proc drop_block(self: Build) =
   if self.drawing:
     var p = self.draw_transform.origin.snapped(vec3(1, 1, 1))
@@ -321,6 +327,7 @@ method on_begin_move*(
         self.voxels_remaining_this_frame -= 1
         self.drop_block()
 
+      self.sync_turtle()
       if count.float >= steps: NEXT_TASK else: RUNNING
 
 method on_begin_turn*(
@@ -366,10 +373,12 @@ method on_begin_turn*(
     self.draw_transform_value.basis =
       self.draw_transform.basis.rotated(axis, deg_to_rad(degrees))
     self.draw_transform = self.draw_transform.orthonormalized()
+    self.sync_turtle()
 
 proc reset_state*(self: Build) =
   self.init_shared
   self.draw_transform = Transform.init
+  self.sync_turtle()
   self.transform = self.start_transform
 
 method reset*(self: Build) =
@@ -435,6 +444,8 @@ proc init*(
       voxels: voxels,
       start_transform: transform,
       draw_transform_value: EdValue[Transform].init(Transform.init, flags = {}),
+      turtle_transform_value:
+        EdValue[Transform].init(Transform.init, flags = {SYNC_LOCAL, SYNC_REMOTE}),
       start_color: color,
       drawing: true,
       bounds_value: ed(init_aabb(vec3(), vec3(-1, -1, -1))),

--- a/src/nodes/turtle_overlay.nim
+++ b/src/nodes/turtle_overlay.nim
@@ -1,0 +1,151 @@
+import pkg/godot except print, Color
+import
+  godotapi/[
+    viewport_container, viewport, camera, mesh_instance, surface_tool,
+    array_mesh, mesh, spatial_material, spatial, environment,
+  ]
+import core, models/[units, builds, colors]
+
+# The turtle indicator: a three-line arrow — shaft plus two barbs — from the
+# centre of the draw cell along the draw heading, rigidly attached to the
+# draw transform. Each line is a thin box (GLES3 has no line width): a
+# bright core inside a wider translucent halo, for a glowy vector-display
+# look.
+
+const
+  CORE_THICKNESS = 0.108'f32
+  HALO_THICKNESS = 0.18'f32
+  ARROW_TIP = -2.0'f32
+  BARB = 0.707'f32 # 1m barbs at 45°: 1 / sqrt(2) per axis
+
+proc arrow_edges(): seq[tuple[a, b: Vector3]] =
+  let tip = vec3(0, 0, ARROW_TIP)
+  result.add (vec3(), tip)
+  result.add (tip, tip + vec3(BARB, 0, BARB))
+  result.add (tip, tip + vec3(-BARB, 0, BARB))
+
+proc add_edge_box(st: SurfaceTool, a, b: Vector3, thickness: float32) =
+  # A segment as a long thin box: 4 side quads, ends extended by the
+  # thickness so corners meet.
+  let d = (b - a).normalized
+  let up = if abs(d.y) > 0.9: vec3(1, 0, 0) else: vec3(0, 1, 0)
+  let s1 = d.cross(up).normalized * thickness
+  let s2 = d.cross(s1).normalized * thickness
+  let a = a - d * thickness
+  let b = b + d * thickness
+  let sides = [s1 + s2, s1 - s2, -s1 - s2, -s1 + s2]
+  for i in 0 .. 3:
+    let (p, q) = (sides[i], sides[(i + 1) mod 4])
+    st.add_vertex(a + p)
+    st.add_vertex(a + q)
+    st.add_vertex(b + q)
+    st.add_vertex(a + p)
+    st.add_vertex(b + q)
+    st.add_vertex(b + p)
+
+proc add_layer(
+    mesh: ArrayMesh, color: chroma.Color, thickness: float32
+): ArrayMesh =
+  var st = gdnew[SurfaceTool]()
+  st.begin(PRIMITIVE_TRIANGLES)
+  st.add_color(color)
+  for (a, b) in arrow_edges():
+    st.add_edge_box(a, b, thickness)
+  st.commit(mesh)
+
+proc arrow_marker(): MeshInstance =
+  let material = gdnew[SpatialMaterial]()
+  material.flags_unshaded = true
+  material.flags_transparent = true
+  material.vertex_color_use_as_albedo = true
+  material.params_cull_mode = CULL_DISABLED
+
+  var halo = col("44ff66")
+  halo.a = 0.3
+  # Halo first, bright core drawn over it (surfaces render in order).
+  var mesh = add_layer(nil, halo, HALO_THICKNESS)
+  mesh = add_layer(mesh, col("e0ffe6"), CORE_THICKNESS)
+
+  result = gdnew[MeshInstance]()
+  result.mesh = mesh
+  result.material_override = material
+  result.cast_shadow = 0
+
+proc arrow_transform(draw_transform: Transform): Transform =
+  ## Build-local transform for the arrow: anchored at the centre of the draw
+  ## cell (origin + half a cell) and turned with the draw basis.
+  var t = draw_transform
+  if t.basis.x == vec3():
+    # The replica starts zeroed until the first sync; a singular basis makes
+    # Godot spam "det == 0".
+    t = Transform.init
+  t.origin = t.origin + vec3(0.5, 0.5, 0.5)
+  t
+
+gdobj TurtleOverlay of ViewportContainer:
+  # Draws the arrow over the world, under the GUI. It lives in its own
+  # transparent viewport whose camera mirrors the world camera each frame,
+  # so it shows through world geometry without touching the world's render
+  # state — anything always-on-top drawn inside the world viewport
+  # (depth-test-disable or near-plane depth squash) makes the terrain's most
+  # recently meshed voxel faces vanish from some angles (GLES3). Sits after
+  # the world container in game.tscn: draws above it, and its process runs
+  # after the player has moved the camera.
+  var
+    overlay: Viewport
+    camera: Camera
+    arrow: MeshInstance
+    world_viewport: Viewport
+
+  method ready*() =
+    self.visible = false
+    self.world_viewport =
+      self.get_node("../ViewportContainer/Viewport") as Viewport
+
+    self.overlay = gdnew[Viewport]()
+    self.overlay.world = gdnew[World]()
+    self.overlay.transparent_bg = true
+    # GLES3 drops the alpha channel from HDR render targets, which turns
+    # transparent_bg into an opaque black square over the world.
+    self.overlay.hdr = false
+    self.overlay.usage = USAGE_3D_NO_EFFECTS
+    # Renders only while the container is shown — no cost with no editor open.
+    self.overlay.render_target_update_mode = UPDATE_WHEN_VISIBLE
+    self.overlay.gui_disable_input = true
+    self.add_child(self.overlay)
+
+    self.camera = gdnew[Camera]()
+    # The project's default environment draws an opaque background even with
+    # transparent_bg; override it with a bare clear-color one.
+    let env = gdnew[Environment]()
+    env.background_mode = BG_CLEAR_COLOR
+    self.camera.environment = env
+    self.overlay.add_child(self.camera)
+    self.camera.make_current()
+
+    self.arrow = arrow_marker()
+    self.arrow.visible = false
+    self.overlay.add_child(self.arrow)
+
+  method process*(delta: float) =
+    # `stretch` only sizes child viewports on the container's own resize
+    # events, which happened before ready() added ours — a 0x0 render target
+    # composites as an opaque black rect.
+    if self.overlay.size != self.rect_size:
+      self.overlay.size = self.rect_size
+
+    var show = false
+    let unit = state.open_unit
+    if ?unit and unit of Build and ?unit.node:
+      let world_camera = self.world_viewport.get_camera()
+      if ?world_camera:
+        show = true
+        self.camera.fov = world_camera.fov
+        self.camera.near = world_camera.near
+        self.camera.far = world_camera.far
+        self.camera.global_transform = world_camera.global_transform
+        self.arrow.global_transform =
+          unit.node.global_transform *
+          arrow_transform(Build(unit).turtle_transform)
+    self.arrow.visible = show
+    self.visible = show

--- a/src/types.nim
+++ b/src/types.nim
@@ -364,6 +364,11 @@ type
     chunk_deltas*: EdTable[Vector3, EdSeq[DeltaUpdate]]
     voxels*: VoxelStore
     draw_transform_value*: EdValue[Transform]
+    # draw_transform mirrored for the render side (turtle indicator). A separate
+    # field because draw_transform is written per voxel — syncing it directly
+    # would flood the context queue during ASAP draws. This one is written once
+    # per batch (see sync_turtle).
+    turtle_transform_value*: EdValue[Transform]
     voxels_per_frame*: float
     voxels_remaining_this_frame*: float
     drawing*: bool


### PR DESCRIPTION
When a build's code editor is open, its draw point is shown as a **glowing three-line arrow** in-world: a 2m shaft from the centre of the draw cell along the draw heading, plus two 1m barbs at the tip. Lines are thin boxes (GLES3 has no line width) — a bright core inside a wider translucent halo, for a vector-display glow. It renders **over the world and under the UI**, only while that build's editor is open, and only for the player who has it open.

## Implementation notes

`draw_transform` is written per voxel (thousands of times a frame in ASAP draws), so syncing it directly would flood the context queue. A new `turtle_transform` field on `Build` mirrors it once per batch (`sync_turtle`).

**The arrow renders in a dedicated overlay viewport** (`TurtleOverlay` in game.tscn: world container → overlay → GUI), with a camera mirrored from the world camera each frame. It is deliberately *not* drawn inside the world viewport: anything always-on-top there — `FLAG_DISABLE_DEPTH_TEST` or a near-plane depth squash in a shader — reliably makes the terrain's most recently meshed voxel faces vanish from some camera angles (GLES3; bisected: the marker overlapping the face on screen is the trigger). With the overlay, marker pixels never enter the world's render, so the artifact can't occur; it also costs nothing when no editor is open (`UPDATE_WHEN_VISIBLE` + hidden container).

Since only one editor is open at a time, one global arrow suffices — `BuildNode` is untouched. GLES3 gotchas encoded in comments: the overlay needs explicit size sync (`stretch` only fires on container resize; a 0×0 target composites as opaque black), `hdr = false` (HDR drops alpha), and a clear-color environment.

**This changes the sync wire format** — rebuild `bin/enu` (`nim build_mcp`) and reconnect any MCP session.

Also observed while testing (pre-existing on main, not addressed here): the MCP `wait_for_script` render-wait is broken — its `pending_block_updates` eval fails (undeclared field), so it returns before rendering settles and can sample bounds before a fresh reload starts running. **A proper fix already exists on the `course` branch** (waits for `SCRIPT_RUNNING` to clear, requires a settled streak of zero pending block updates, surfaces script errors; plus `b847b05d` fixes the underlying reload race), so it needs no new work here — it arrives whenever `course` lands.

## Verified

Headlessly via composited captures (`screenshot_from_player --with_ui`) across several design iterations: arrow anchored at the draw cell centre and tracking the heading (axis-aligned, `turn right`, `turn 45`); markers show through world geometry; absent with no editor open; world render unaffected from the previously-failing angle. `nim test` / `test_world` / `test_mcp` green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Fffdsy1QgTiV3GKfVMSTNi