### PR TITLE
build(deps): route fork deps via atlas nameOverrides; bump ed to 0.30.4

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -41,7 +41,11 @@ nimble.paths
 
 *.previous
 .claude/
-deps/
+# Ignore Atlas-managed dep checkouts + machine caches, but track atlas.config --
+# it carries the portable resolution policy (fork nameOverrides). Contents-glob
+# so the exception can re-include a child (a bare `deps/` ignore can't be negated).
+deps/*
+!deps/atlas.config
 nimbledeps/
 nim.cfg
 .build_arch

--- a/atlas.lock
+++ b/atlas.lock
@@ -15,7 +15,7 @@
     "ed.getenu.github.com": {
       "dir": "$deps/ed",
       "url": "https://github.com/getenu/ed",
-      "commit": "adcfbce054c122be63ddf303ad9b3d7b45a8c930",
+      "commit": "19650b3dfc3573372bedbb0883d6c33df7b1dc99",
       "version": ""
     },
     "nanoid.nim.getenu.github.com": {
@@ -328,7 +328,7 @@
       "",
       "requires \"https://github.com/getenu/Nim#bea4c144\",",
       "  \"godot 0.8.6\",",
-      "  \"ed 0.30.4\",",
+      "  \"ed 0.30.5\",",
       "  \"nanoid >= 0.2.1\",",
       "  \"pretty\", \"cligen\", \"chroma\", \"markdown\",",
       "  \"chronicles\", \"dotenv\", \"nimibook\", \"metrics#a1296ca\", \"zippy\", \"unittest2\",",

--- a/atlas.lock
+++ b/atlas.lock
@@ -15,7 +15,7 @@
     "ed.getenu.github.com": {
       "dir": "$deps/ed",
       "url": "https://github.com/getenu/ed",
-      "commit": "7b564cf1c1e07d732b7ce149154ba467c8155dae",
+      "commit": "adcfbce054c122be63ddf303ad9b3d7b45a8c930",
       "version": ""
     },
     "nanoid.nim.getenu.github.com": {
@@ -120,10 +120,10 @@
       "commit": "c5a39a039f24d48ba9503dcb9a0aee68a0fbb36d",
       "version": ""
     },
-    "flatty": {
+    "flatty.getenu.github.com": {
       "dir": "$deps/flatty",
-      "url": "https://github.com/treeform/flatty",
-      "commit": "07f6ba8ab96238e5bd1264cf0cea1d1746abb00c",
+      "url": "https://github.com/getenu/flatty",
+      "commit": "3f76ca47c9f42185cbf563af4fd298cd72c05bf4",
       "version": ""
     },
     "netty": {
@@ -327,15 +327,15 @@
       "src_dir = \"src\"",
       "",
       "requires \"https://github.com/getenu/Nim#bea4c144\",",
-      "  \"https://github.com/getenu/godot-nim 0.8.6\",",
-      "  \"https://github.com/getenu/ed 0.30.3\",",
-      "  \"https://github.com/getenu/nanoid.nim >= 0.2.1\",",
-      "  \"https://github.com/treeform/pretty >= 0.2.0\", \"cligen\", \"chroma\", \"markdown\",",
+      "  \"godot 0.8.6\",",
+      "  \"ed 0.30.4\",",
+      "  \"nanoid >= 0.2.1\",",
+      "  \"pretty\", \"cligen\", \"chroma\", \"markdown\",",
       "  \"chronicles\", \"dotenv\", \"nimibook\", \"metrics#a1296ca\", \"zippy\", \"unittest2\",",
-      "  \"https://github.com/getenu/nph#948b933\", \"regex\",",
-      "  \"https://github.com/getenu/nimcp 0.10.0\",",
-      "  \"https://github.com/gokr/mummyx#32f0ef97\",",
-      "  \"https://github.com/dsrw/nim-libbacktrace\"",
+      "  \"nph#948b933\", \"regex\",",
+      "  \"nimcp 0.10.0\",",
+      "  \"mummy#32f0ef97\",",
+      "  \"libbacktrace\"",
       ""
     ]
   },

--- a/deps/atlas.config
+++ b/deps/atlas.config
@@ -1,0 +1,18 @@
+{
+  "deps": "deps",
+  "nameOverrides": {
+    "nimcp": "https://github.com/getenu/nimcp",
+    "nanoid": "https://github.com/getenu/nanoid.nim",
+    "mummy": "https://github.com/gokr/mummyx",
+    "flatty": "https://github.com/getenu/flatty",
+    "godot": "https://github.com/getenu/godot-nim",
+    "ed": "https://github.com/getenu/ed",
+    "nph": "https://github.com/getenu/nph",
+    "libbacktrace": "https://github.com/dsrw/nim-libbacktrace"
+  },
+  "urlOverrides": {},
+  "pkgOverrides": {},
+  "plugins": "",
+  "resolver": "SemVer",
+  "graph": null
+}

--- a/enu.nimble
+++ b/enu.nimble
@@ -8,7 +8,7 @@ src_dir = "src"
 
 requires "https://github.com/getenu/Nim#bea4c144",
   "godot 0.8.6",
-  "ed 0.30.4",
+  "ed 0.30.5",
   "nanoid >= 0.2.1",
   "pretty", "cligen", "chroma", "markdown",
   "chronicles", "dotenv", "nimibook", "metrics#a1296ca", "zippy", "unittest2",

--- a/enu.nimble
+++ b/enu.nimble
@@ -7,12 +7,12 @@ bin_dir = "app"
 src_dir = "src"
 
 requires "https://github.com/getenu/Nim#bea4c144",
-  "https://github.com/getenu/godot-nim 0.8.6",
-  "https://github.com/getenu/ed 0.30.3",
-  "https://github.com/getenu/nanoid.nim >= 0.2.1",
-  "https://github.com/treeform/pretty >= 0.2.0", "cligen", "chroma", "markdown",
+  "godot 0.8.6",
+  "ed 0.30.4",
+  "nanoid >= 0.2.1",
+  "pretty", "cligen", "chroma", "markdown",
   "chronicles", "dotenv", "nimibook", "metrics#a1296ca", "zippy", "unittest2",
-  "https://github.com/getenu/nph#948b933", "regex",
-  "https://github.com/getenu/nimcp 0.10.0",
-  "https://github.com/gokr/mummyx#32f0ef97",
-  "https://github.com/dsrw/nim-libbacktrace"
+  "nph#948b933", "regex",
+  "nimcp 0.10.0",
+  "mummy#32f0ef97",
+  "libbacktrace"


### PR DESCRIPTION
## What

Move enu's forked-dependency URLs out of `enu.nimble` and into
`deps/atlas.config` `nameOverrides`, so requires read as plain package names.
Bumps **ed 0.30.3 → 0.30.4**, which pulls the hardened `getenu/flatty` fork
(bounds-checked wire decode); flatty now resolves to getenu everywhere in the
graph (both ed and netty pull it) via the override, not treeform.

| require before | now | override |
|---|---|---|
| `getenu/godot-nim 0.8.6` | `godot 0.8.6` | `godot` → getenu/godot-nim |
| `getenu/ed 0.30.3` | `ed 0.30.4` | `ed` → getenu/ed |
| `getenu/nanoid.nim >= 0.2.1` | `nanoid >= 0.2.1` | `nanoid` → getenu/nanoid.nim |
| `treeform/pretty >= 0.2.0` | `pretty` | none (registry) |
| `getenu/nph#948b933` | `nph#948b933` | `nph` → getenu/nph |
| `getenu/nimcp 0.10.0` | `nimcp 0.10.0` | `nimcp` → getenu/nimcp |
| `gokr/mummyx#32f0ef97` | `mummy#32f0ef97` | `mummy` → gokr/mummyx |
| `dsrw/nim-libbacktrace` | `libbacktrace` | `libbacktrace` → dsrw/nim-libbacktrace |
| `getenu/Nim#bea4c144` | **unchanged (URL)** | — |

The override keys are the *package* names (from each fork's nimble file), which
differ from the repo names in three cases: `mummyx`→`mummy`, `godot-nim`→`godot`,
`nim-libbacktrace`→`libbacktrace`. `nameOverrides` maps a name to a URL for every
resolution including transitive ones, so this also redirects netty's plain
`flatty` — no duplicate-module conflict.

## Nim stays a URL — on purpose

Atlas special-cases the compiler package: when `Nim` is resolved by name it gets
dropped from `atlas.lock`, which breaks `tasks.nim`'s `dep_dir("Nim")` (it reads
the Nim checkout dir from the lock to build the compiler / VM). Kept as a URL
require so it stays locked. URL requires and nameOverrides coexist fine.

## Tracking + lock

- `deps/atlas.config` is now tracked (gitignore `deps/*` + `!deps/atlas.config`);
  it's the portable resolution policy, unlike the machine-specific `atlas.cache*`.
- `atlas.lock` regenerated (`atlas pin`). The diff is scoped: only **ed**
  (`7b564cf`→`adcfbce`, 0.30.4) and **flatty** (treeform→getenu `3f76ca4`,
  hardened) move; no other dep version changes.

## Validation

- `atlas install` resolves cleanly (exit 0, zero errors); all deps check out,
  including ed 0.30.4, getenu/flatty, and the Nim fork at the pinned commit.
- ed + flatty compile against enu (verified via `nim check` up to enu's own
  compiler-VM modules).
- **Not run in this environment:** a full Godot / forked-Nim build (needs the
  vendored Godot toolchain + koch-built compiler). Worth a CI/local build
  confirm before merge, but the dep-resolution surface this PR touches is green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_014o1niF74BvbfxYU1oWEQ38