### PR TITLE
API reference docs for 0.3

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -27,6 +27,7 @@ app/enu.lib
 generated/
 app/export_presets.cfg
 docs/build
+docs/book/api/json/
 dist/
 share/vmlib/stdlib
 dist_config.json

--- a/docs/api_docs.nim
+++ b/docs/api_docs.nim
@@ -29,6 +29,7 @@ type
     enums*: seq[Symbol]
     types*: Table[string, TypeDoc]  # Type name -> TypeDoc
     free_procs*: seq[Symbol]  # Procs that don't operate on an exported type
+    module_descriptions*: Table[string, string]  # Module name -> doc comment
 
   ModuleConfig* = tuple[name: string, json: string]
 
@@ -122,6 +123,10 @@ proc collect_symbols*(
       continue
 
     let doc = parse_json(json_content)
+    let module_description =
+      doc.get_or_default("moduleDescription").get_str.strip
+    if module_description.len > 0:
+      result.module_descriptions[module_name] = module_description
     if "entries" notin doc:
       continue
 
@@ -268,16 +273,29 @@ proc group_overloads_by_comment*(overloads: seq[Symbol]): seq[OverloadGroup] =
 
 # Mustache context generation - returns JsonNode for direct use with Mustache
 
-proc to_symbol_json*(sym: Symbol, suffix: string = ""): JsonNode =
+proc source_url*(sym: Symbol, source_template: string): string =
+  ## Expand a source link template like
+  ## "https://github.com/getenu/enu/blob/main/share/vmlib/$module.nim#L$line"
+  if source_template.len == 0 or sym.module.len == 0:
+    ""
+  else:
+    source_template.replace("$module", sym.module).replace("$line", $sym.line)
+
+proc to_symbol_json*(
+    sym: Symbol, suffix: string = "", source_template = ""
+): JsonNode =
+  let url = sym.source_url(source_template)
   result = %*{
     "name": sym.name.to_display_name,
     "anchor": generate_anchor(sym.name, suffix),
     "description": sym.description,
     "code": highlight_code(sym.code),
-    "module": sym.module
+    "module": sym.module,
+    "hasSourceUrl": url.len > 0,
+    "sourceUrl": url
   }
 
-proc to_api_json*(data: DocData): JsonNode =
+proc to_api_json*(data: DocData, source_template = ""): JsonNode =
   ## Convert DocData to JSON for Mustache template
   result = %*{
     "hasConstants": data.constants.len > 0,
@@ -291,11 +309,11 @@ proc to_api_json*(data: DocData): JsonNode =
 
   # Constants
   for sym in data.constants:
-    result["constants"].add(sym.to_symbol_json("const"))
+    result["constants"].add(sym.to_symbol_json("const", source_template))
 
   # Enums
   for sym in data.enums:
-    result["enums"].add(sym.to_symbol_json("enum"))
+    result["enums"].add(sym.to_symbol_json("enum", source_template))
 
   # Free procs - group by module, then by name, then by doc comments
   if data.free_procs.len > 0:
@@ -310,9 +328,24 @@ proc to_api_json*(data: DocData): JsonNode =
     module_names.sort()
 
     for module_name in module_names:
+      let full_module = procs_by_module[module_name][0].module
+      let description = data.module_descriptions.get_or_default(full_module)
+      let url =
+        if source_template.len == 0:
+          ""
+        else:
+          source_template
+            .replace("#L$line", "")
+            .replace("$line", "")
+            .replace("$module", full_module)
       var mc = %*{
         "name": module_name,
         "anchor": generate_anchor(module_name, "module"),
+        "module": full_module,
+        "hasDescription": description.len > 0,
+        "description": description,
+        "hasSourceUrl": url.len > 0,
+        "sourceUrl": url,
         "procs": new_j_array()
       }
 
@@ -364,6 +397,8 @@ proc to_api_json*(data: DocData): JsonNode =
       "description": "",
       "code": "",
       "module": "",
+      "hasSourceUrl": false,
+      "sourceUrl": "",
       "hasStaticProcs": td.static_procs.len > 0,
       "staticProcs": new_j_array(),
       "hasProcs": td.procs.len > 0,
@@ -373,9 +408,12 @@ proc to_api_json*(data: DocData): JsonNode =
     }
 
     if td.has_type:
+      let url = td.type_symbol.source_url(source_template)
       tc["description"] = %td.type_symbol.description
       tc["code"] = %highlight_code(td.type_symbol.code)
       tc["module"] = %td.type_symbol.module
+      tc["hasSourceUrl"] = %(url.len > 0)
+      tc["sourceUrl"] = %url
 
     # Static procs - group by display name, then by doc comments
     if td.static_procs.len > 0:

--- a/docs/api_docs.nim
+++ b/docs/api_docs.nim
@@ -245,8 +245,8 @@ proc group_overloads_by_comment*(overloads: seq[Symbol]): seq[OverloadGroup] =
   var current_group = OverloadGroup(description: "", codes: @[], modules: @[])
 
   for ovl in overloads:
-    if ovl.description.len > 0:
-      # This overload has a comment - start a new group
+    if ovl.description.len > 0 and ovl.description != current_group.description:
+      # This overload has a different comment - start a new group
       if current_group.codes.len > 0:
         # Save the previous group first
         groups.add(current_group)
@@ -256,7 +256,7 @@ proc group_overloads_by_comment*(overloads: seq[Symbol]): seq[OverloadGroup] =
         modules: @[ovl.module]
       )
     else:
-      # No comment - add to current group
+      # No comment (or the same one) - add to current group
       current_group.codes.add(ovl.code)
       current_group.modules.add(ovl.module)
 

--- a/docs/api_docs.nim
+++ b/docs/api_docs.nim
@@ -28,6 +28,7 @@ type
     constants*: seq[Symbol]
     enums*: seq[Symbol]
     types*: Table[string, TypeDoc]  # Type name -> TypeDoc
+    free_procs*: seq[Symbol]  # Procs that don't operate on an exported type
 
   ModuleConfig* = tuple[name: string, json: string]
 
@@ -94,7 +95,9 @@ proc parse_symbol*(entry: JsonNode, module: string): Symbol =
   result.module = module
   result.is_static = is_static_method(entry)
 
-proc collect_symbols*(modules: seq[ModuleConfig]): DocData =
+proc collect_symbols*(
+    modules: seq[ModuleConfig], include_free_procs = false
+): DocData =
   ## Collect symbols from pre-loaded JSON module data
   result.types = init_table[string, TypeDoc]()
   var seen_names = init_hash_set[string]()
@@ -126,7 +129,8 @@ proc collect_symbols*(modules: seq[ModuleConfig]): DocData =
       let name = entry["name"].get_str
       let entry_type = entry["type"].get_str
 
-      if name.starts_with("_") or name.contains("gensym"):
+      if name.starts_with("_") or name.contains("gensym") or
+          name.ends_with("_impl"):
         continue
 
       # Include code signature to distinguish overloads
@@ -161,6 +165,8 @@ proc collect_symbols*(modules: seq[ModuleConfig]): DocData =
             result.types[op_type].static_procs.add(symbol)
           else:
             result.types[op_type].procs.add(symbol)
+        elif include_free_procs:
+          result.free_procs.add(symbol)
       else:
         discard
 
@@ -218,7 +224,8 @@ proc generate_anchor*(name: string, suffix: string = ""): string =
   base.to_lower_ascii.multi_replace([
     ("[", ""), ("]", ""), ("=", "eq"), (",", "_"), (" ", "_"),
     ("(", ""), (")", ""), ("*", ""), ("+", "plus"), ("-", ""),
-    ("&", "amp"), ("?", "q"), ("$", "dollar"), ("`", ""), (".", "_")
+    ("&", "amp"), ("?", "q"), ("$", "dollar"), ("`", ""), (".", "_"),
+    ("<", "lt"), (">", "gt")
   ])
 
 type
@@ -277,6 +284,8 @@ proc to_api_json*(data: DocData): JsonNode =
     "constants": new_j_array(),
     "hasEnums": data.enums.len > 0,
     "enums": new_j_array(),
+    "hasFreeProcs": data.free_procs.len > 0,
+    "freeProcModules": new_j_array(),
     "types": new_j_array()
   }
 
@@ -287,6 +296,59 @@ proc to_api_json*(data: DocData): JsonNode =
   # Enums
   for sym in data.enums:
     result["enums"].add(sym.to_symbol_json("enum"))
+
+  # Free procs - group by module, then by name, then by doc comments
+  if data.free_procs.len > 0:
+    var procs_by_module = init_table[string, seq[Symbol]]()
+    for p in data.free_procs:
+      let module = p.module.split('/')[^1]
+      if module notin procs_by_module:
+        procs_by_module[module] = @[]
+      procs_by_module[module].add(p)
+
+    var module_names = to_seq(procs_by_module.keys)
+    module_names.sort()
+
+    for module_name in module_names:
+      var mc = %*{
+        "name": module_name,
+        "anchor": generate_anchor(module_name, "module"),
+        "procs": new_j_array()
+      }
+
+      var procs_by_name = init_table[string, seq[Symbol]]()
+      for p in procs_by_module[module_name]:
+        if p.name notin procs_by_name:
+          procs_by_name[p.name] = @[]
+        procs_by_name[p.name].add(p)
+
+      var proc_names = to_seq(procs_by_name.keys)
+      proc_names.sort()
+
+      for proc_name in proc_names:
+        let overloads = procs_by_name[proc_name]
+        let proc_anchor =
+          generate_anchor(proc_name.decode_html_entities, module_name)
+        let groups = group_overloads_by_comment(overloads)
+
+        var pc = %*{
+          "name": proc_name.to_display_name,
+          "anchor": proc_anchor,
+          "module": module_name,
+          "groups": new_j_array()
+        }
+
+        for group in groups:
+          let combined_code = join_code_blocks(group.codes)
+          pc["groups"].add(%*{
+            "description": group.description,
+            "hasDescription": group.description.len > 0,
+            "code": combined_code
+          })
+
+        mc["procs"].add(pc)
+
+      result["freeProcModules"].add(mc)
 
   # Types - sorted by name
   var type_names = to_seq(data.types.keys)

--- a/docs/book.nim
+++ b/docs/book.nim
@@ -14,6 +14,7 @@ var book = init_book_with_toc:
     entry "Built-in Commands", "coding/commands"
     entry "Shorthand Commands", "coding/shorthand"
     entry "Random Numbers", "coding/random_numbers"
+    entry "API Reference", "api/enu_api"
 
   section "Command Loops", "command_loops":
     entry "Writing Commands", "command_loops/commands"

--- a/docs/book/api/ed_api.nim
+++ b/docs/book/api/ed_api.nim
@@ -1,9 +1,17 @@
 ## Ed API Reference
 ## Generates API documentation page for Ed reactive data framework.
 
+import std/[strutils, osproc]
 import nimib, nimibook
 import ../../enuib
 import ../../api_docs
+
+# Pin source links to the Ed commit the docs were built from. Resolved
+# when the page runs (during the docs build) so it can't go stale in the
+# compile cache.
+let ed_commit = exec_process(
+    "git -C \"$(git rev-parse --show-toplevel)/deps/ed\" rev-parse HEAD"
+  ).strip
 
 # Load JSON documentation files at compile time.
 # Generated from deps/ed by the `docs` task (generate_api_json in tasks.nim).
@@ -29,7 +37,7 @@ nb_init(theme = use_api_docs)
 # Collect symbols and convert to JSON for Mustache
 let data = collect_symbols(modules)
 let api_json = data.to_api_json(
-  "https://github.com/getenu/ed/blob/main/src/$module.nim#L$line"
+  "https://github.com/getenu/ed/blob/" & ed_commit & "/src/$module.nim#L$line"
 )
 
 # Set API context for template

--- a/docs/book/api/ed_api.nim
+++ b/docs/book/api/ed_api.nim
@@ -5,13 +5,14 @@ import nimib, nimibook
 import ../../enuib
 import ../../api_docs
 
-# Load JSON documentation files at compile time
+# Load JSON documentation files at compile time.
+# Generated from deps/ed by the `docs` task (generate_api_json in tasks.nim).
 const
-  types_json = static_read("../../../../model_citizen/docs/json/ed/types.json")
-  initializers_json = static_read("../../../../model_citizen/docs/json/ed/zens/initializers.json")
-  operations_json = static_read("../../../../model_citizen/docs/json/ed/zens/operations.json")
-  contexts_json = static_read("../../../../model_citizen/docs/json/ed/zens/contexts.json")
-  validations_json = static_read("../../../../model_citizen/docs/json/ed/zens/validations.json")
+  types_json = static_read("json/ed/types.json")
+  initializers_json = static_read("json/ed/zens/initializers.json")
+  operations_json = static_read("json/ed/zens/operations.json")
+  contexts_json = static_read("json/ed/zens/contexts.json")
+  validations_json = static_read("json/ed/zens/validations.json")
 
 # Configure modules with their JSON content
 const modules: seq[ModuleConfig] = @[

--- a/docs/book/api/ed_api.nim
+++ b/docs/book/api/ed_api.nim
@@ -28,7 +28,9 @@ nb_init(theme = use_api_docs)
 
 # Collect symbols and convert to JSON for Mustache
 let data = collect_symbols(modules)
-let api_json = data.to_api_json()
+let api_json = data.to_api_json(
+  "https://github.com/getenu/ed/blob/main/src/$module.nim#L$line"
+)
 
 # Set API context for template
 nb.context["api"] = api_json

--- a/docs/book/api/ed_readme.nim
+++ b/docs/book/api/ed_readme.nim
@@ -6,15 +6,16 @@ import ../../enuib
 import ../../api_docs
 
 # Load README at compile time
-const readme_md = static_read("../../../../model_citizen/README.md")
+const readme_md = static_read("../../../deps/ed/README.md")
 
-# Load JSON documentation files for sidebar
+# Load JSON documentation files for sidebar.
+# Generated from deps/ed by the `docs` task (generate_api_json in tasks.nim).
 const
-  types_json = static_read("../../../../model_citizen/docs/json/ed/types.json")
-  initializers_json = static_read("../../../../model_citizen/docs/json/ed/zens/initializers.json")
-  operations_json = static_read("../../../../model_citizen/docs/json/ed/zens/operations.json")
-  contexts_json = static_read("../../../../model_citizen/docs/json/ed/zens/contexts.json")
-  validations_json = static_read("../../../../model_citizen/docs/json/ed/zens/validations.json")
+  types_json = static_read("json/ed/types.json")
+  initializers_json = static_read("json/ed/zens/initializers.json")
+  operations_json = static_read("json/ed/zens/operations.json")
+  contexts_json = static_read("json/ed/zens/contexts.json")
+  validations_json = static_read("json/ed/zens/validations.json")
 
 const modules: seq[ModuleConfig] = @[
   ("ed/types", types_json),

--- a/docs/book/api/enu_api.nim
+++ b/docs/book/api/enu_api.nim
@@ -2,9 +2,15 @@
 ## Generates the API documentation page for the Enu scripting API
 ## (share/vmlib/enu).
 
+import std/[strutils, osproc]
 import nimib, nimibook
 import ../../enuib
 import ../../api_docs
+
+# Pin source links to the commit the docs were built from. Resolved when
+# the page runs (during the docs build) so it can't go stale in the
+# compile cache.
+let enu_commit = exec_process("git rev-parse HEAD").strip
 
 # Load JSON documentation files at compile time.
 # Generated from share/vmlib/enu by the `docs` task (generate_api_json in
@@ -40,7 +46,8 @@ nb_init(theme = use_enu_api_docs)
 
 let data = collect_symbols(modules, include_free_procs = true)
 nb.context["api"] = data.to_api_json(
-  "https://github.com/getenu/enu/blob/main/share/vmlib/$module.nim#L$line"
+  "https://github.com/getenu/enu/blob/" & enu_commit &
+    "/share/vmlib/$module.nim#L$line"
 )
 
 nb_save

--- a/docs/book/api/enu_api.nim
+++ b/docs/book/api/enu_api.nim
@@ -11,8 +11,9 @@ import ../../api_docs
 # tasks.nim).
 const
   types_json = static_read("json/enu/types.json")
+  vectors_json = static_read("json/enu/vectors.json")
   base_bridge_json = static_read("json/enu/base_bridge.json")
-  base_api_json = static_read("json/enu/base_api.json")
+  core_json = static_read("json/enu/core.json")
   builds_json = static_read("json/enu/builds.json")
   bots_json = static_read("json/enu/bots.json")
   players_json = static_read("json/enu/players.json")
@@ -23,8 +24,9 @@ const
 
 const modules: seq[ModuleConfig] = @[
   ("enu/types", types_json),
+  ("enu/vectors", vectors_json),
   ("enu/base_bridge", base_bridge_json),
-  ("enu/base_api", base_api_json),
+  ("enu/core", core_json),
   ("enu/builds", builds_json),
   ("enu/bots", bots_json),
   ("enu/players", players_json),

--- a/docs/book/api/enu_api.nim
+++ b/docs/book/api/enu_api.nim
@@ -39,6 +39,8 @@ const modules: seq[ModuleConfig] = @[
 nb_init(theme = use_enu_api_docs)
 
 let data = collect_symbols(modules, include_free_procs = true)
-nb.context["api"] = data.to_api_json()
+nb.context["api"] = data.to_api_json(
+  "https://github.com/getenu/enu/blob/main/share/vmlib/$module.nim#L$line"
+)
 
 nb_save

--- a/docs/book/api/enu_api.nim
+++ b/docs/book/api/enu_api.nim
@@ -1,0 +1,42 @@
+## Enu API Reference
+## Generates the API documentation page for the Enu scripting API
+## (share/vmlib/enu).
+
+import nimib, nimibook
+import ../../enuib
+import ../../api_docs
+
+# Load JSON documentation files at compile time.
+# Generated from share/vmlib/enu by the `docs` task (generate_api_json in
+# tasks.nim).
+const
+  types_json = static_read("json/enu/types.json")
+  base_bridge_json = static_read("json/enu/base_bridge.json")
+  base_api_json = static_read("json/enu/base_api.json")
+  builds_json = static_read("json/enu/builds.json")
+  bots_json = static_read("json/enu/bots.json")
+  players_json = static_read("json/enu/players.json")
+  signs_json = static_read("json/enu/signs.json")
+  state_machine_json = static_read("json/enu/state_machine.json")
+  worlds_json = static_read("json/enu/worlds.json")
+  testing_json = static_read("json/enu/testing.json")
+
+const modules: seq[ModuleConfig] = @[
+  ("enu/types", types_json),
+  ("enu/base_bridge", base_bridge_json),
+  ("enu/base_api", base_api_json),
+  ("enu/builds", builds_json),
+  ("enu/bots", bots_json),
+  ("enu/players", players_json),
+  ("enu/signs", signs_json),
+  ("enu/state_machine", state_machine_json),
+  ("enu/worlds", worlds_json),
+  ("enu/testing", testing_json),
+]
+
+nb_init(theme = use_enu_api_docs)
+
+let data = collect_symbols(modules, include_free_procs = true)
+nb.context["api"] = data.to_api_json()
+
+nb_save

--- a/docs/book/assets/css/api.css
+++ b/docs/book/assets/css/api.css
@@ -21,6 +21,15 @@
   margin: 0;
 }
 
+/* Inline code in doc comments */
+.description tt.docutils {
+  color: #96CBFE;
+}
+
+.description tt.docutils span {
+  color: inherit;
+}
+
 /* Section headers fill the sidebar row so the [+]/[-] marker right-aligns */
 .sidebar .chapter-item > .api-nav-header {
   flex: 1;

--- a/docs/book/assets/css/api.css
+++ b/docs/book/assets/css/api.css
@@ -21,6 +21,12 @@
   margin: 0;
 }
 
+/* Section headers fill the sidebar row so the [+]/[-] marker right-aligns */
+.sidebar .chapter-item > .api-nav-header {
+  flex: 1;
+  margin-right: 20px;
+}
+
 /* Type items with details/summary for collapsing operations */
 .api-type-details {
   margin: 0;

--- a/docs/book/coding/commands.md
+++ b/docs/book/coding/commands.md
@@ -29,14 +29,14 @@ move enemy
 up 5
 ```
 
-It's also possible to call commands directly against a unit instance, but they
-will always use `move` mode, regardless
-of which mode is in use:
+It's also possible to call commands directly against a unit instance. They use
+whichever `move`/`build` mode is currently active, but don't change the current
+target:
 
 ```nim
 build enemy
-up 5 # build 5 blocks up
-enemy.up 5 # move up 5
+up 5 # enemy builds 5 blocks up
+me.up 5 # me builds 5 blocks up. enemy is still the build target.
 ```
 
 ## `forward` / `back` / `up` / `down` / `left` / `right`
@@ -82,15 +82,12 @@ if player.far(25):
 
 ## `hit`
 
-If a unit is touching another unit, return the vector of the contact. Defaults
-to testing against `me`. For example:
+Returns `true` if a unit is touching another unit. Defaults to testing against
+`me`. For example:
 
 ```nim
 if player.hit:
   echo "I'm touching the player"
-
-if player.hit == UP:
-  echo "The player is on top of me"
 
 if player.hit(enemy1):
   echo "The player hit enemy1"
@@ -125,7 +122,8 @@ forever:
 
 ## `start_position`
 
-The starting position of a unit. Missing currently, but will be in in 0.2.
+Gets or sets the starting position of a unit. Setting it updates the unit's
+spawn position, which persists across reloads.
 
 ## `speed` / `speed=`
 
@@ -141,7 +139,7 @@ Switching between build and move mode doesn't impact the speed, except in the
 case of switching to move mode from build mode with a speed of 0. `speed = 0` is
 extremely common for build mode, but makes things appear broken in move mode, as
 nothing will actually move, so switching to move mode with a speed of 0 will
-automatically reset the speed to 5.
+automatically reset the speed to 1.
 
 ## `scale` / `scale=`
 
@@ -164,7 +162,7 @@ By default, new `Build` units are `global = false` and new `Bot` units are
 
 ## `rotation`
 
-Gets the rotation of a unit as a Vector3.
+Gets the rotation of a unit, in degrees.
 
 ## `velocity` / `velocity=`
 
@@ -190,17 +188,17 @@ enable saving/restoring multiple points.
 
 Instantly return unit to start position and resets rotation and scale.
 
-## `home`
+## `go_home`
 
 Moves a unit to its start position via a `forward`, `left`, `down` sequence with
 appropriate values. Can fail if there are obstructions along the way. Compare
 `position` to `start_position` after running to test for success.
 
 ## `sleep`
-`sleep(seconds = -1.0)`
+`sleep(seconds = 0.0)`
 
 Do nothing for the specified number of seconds. If no argument is provided, or
-the argument is < 0, this will wait for 0.5 seconds or until unit is
+the argument is 0 or less, this will wait for 0.5 seconds or until the unit is
 interrupted, which will end the `sleep` prematurely. This allows the following:
 
 ```nim

--- a/docs/book/demos.md
+++ b/docs/book/demos.md
@@ -6,7 +6,7 @@
 
 ## Potato Zombies: Helping a 6 year old build a 3D game with Enu and Nim
 
-Initially presented at [FOSDOM 2022](https://fosdem.org/2022/schedule/event/nim_potatozombies).
+Initially presented at [FOSDEM 2022](https://fosdem.org/2022/schedule/event/nim_potatozombies).
 
 <iframe width="560" height="315" src="https://www.youtube-nocookie.com/embed/UqLy-4rP69I?si=Bk2Z6n6PoNbx7wkb" title="YouTube video player" frameborder="0" allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture; web-share" allowfullscreen></iframe>
 

--- a/docs/book/goals.md
+++ b/docs/book/goals.md
@@ -1,7 +1,7 @@
 # Goals
 
 Enu is meant for anyone who wants to explore, experiment, or make games, but
-particular care has been taken to make it usable by children  However, rather
+particular care has been taken to make it usable by children. However, rather
 than bypassing the keyboard with a Scratch-like visual programming language,
 Enu attempts to reduce and simplify the keystrokes required for a text-based
 language, while (hopefully) preserving most of the flexibility text-based code

--- a/docs/book/intro/building.md
+++ b/docs/book/intro/building.md
@@ -8,15 +8,16 @@ will be fixed in a future release.
 # Build and Run
 
 ```console
-$ nimble prereqs
-$ nimble build
-$ nimble import_assets
-$ nimble start
+$ atlas install && atlas rep
+$ nim prereqs
+$ nim build
+$ nim import_assets
+$ nim start
 ```
 
 ## Notes
 
 Enu requires a custom Godot version, which lives in `vendor/godot`. This will 
-be fetched and built as part of `nimble prereqs`.
+be fetched and built as part of `nim prereqs`.
 
 See [Compiling Godot](https://docs.godotengine.org/en/3.5/development/compiling/index.html).

--- a/docs/book/intro/config.md
+++ b/docs/book/intro/config.md
@@ -64,7 +64,7 @@ a few configurable options:
 ```json
 {
   "font_size": 38,
-  "dock_icon_size": 193.75,
+  "toolbar_size": 193.75,
   "world": "tutorial",
   "level": "tutorial-1",
   "show_stats": true,

--- a/docs/book/intro/controls.md
+++ b/docs/book/intro/controls.md
@@ -13,7 +13,7 @@
 - `Alt`+`Enter` - toggle fullscreen in Windows/Linux.
 - `Cmd`+`Q` / `Ctrl`+`Q` - quit Enu.
 - `1` - enter edit mode.
-- `2 - 9` - change active action.
+- `2 - 8` - change active action.
 - `Mouse Wheel Up` / `Down` - change active action.
 - `Left Alt` / `Left Option` - reload script changes. Hold to temporarily capture the
   mouse and move, so you can change your view without having to switch away from

--- a/docs/book/intro/tutorial.md
+++ b/docs/book/intro/tutorial.md
@@ -48,7 +48,7 @@ friendly robots. Tools `2` - `7` are the `blue`, `red`, `green`, `black`,
 `Bots` are NPCs in Enu, and can be programmed to explore, change their
 appearance, or offer information.
 
-They can be placed with the `left` mouse button or the `R1` gamepad trigger.
+They can be placed with the `left` mouse button or the `L2` gamepad trigger.
 
 ## Coding Enu
 
@@ -59,7 +59,7 @@ language that's useful for a wide variety of tasks. Almost everything in Enu
 can be coded with Nim.
 
 With the `Code` tool selected, you can code anything you've created by clicking
-on it with the `left` mouse button, or `R1` on the controller
+on it with the `left` mouse button, or `L2` on the controller
 
 ## Coding Bots
 

--- a/docs/book/template.html.mustache
+++ b/docs/book/template.html.mustache
@@ -46,6 +46,14 @@
   <!-- Highlight.js Stylesheets - I could use nimib native highlight but let's keep it for styling... -->
   <link rel="stylesheet" href="{{ path_to_root }}assets/css/highlight.css">
 
+  <!-- API reference pages (and the Ed readme, which shares the API sidebar) -->
+  {{#is_api_docs}}
+    <link rel="stylesheet" href="{{ path_to_root }}assets/css/api.css">
+  {{/is_api_docs}}
+  {{#is_readme}}
+    <link rel="stylesheet" href="{{ path_to_root }}assets/css/api.css">
+  {{/is_readme}}
+
   <!-- Custom theme stylesheets - why the "../"? -->
   {{#additional_css}}
     <link rel="stylesheet" href="../{{ path_to_root }}{{ . }}">
@@ -244,7 +252,7 @@
         {{#is_api_docs}}
         <!-- API Reference Section -->
         <section id="api-reference">
-          <h1>Ed API Reference</h1>
+          <h1>{{ api_title }}</h1>
 
           {{#api.hasConstants}}
           <section id="constants">
@@ -326,6 +334,25 @@
             </article>
             {{/api.types}}
           </section>
+
+          {{#api.freeProcModules}}
+          <section id="{{ anchor }}" class="module-section">
+            <h3><a href="#{{ anchor }}"><code>{{ name }}</code></a></h3>
+            {{#procs}}
+            <div class="operation" id="{{ anchor }}">
+              <h5><a href="#{{ anchor }}">{{ name }}</a></h5>
+              {{#groups}}
+              <div class="overload-group">
+                {{#hasDescription}}
+                <p class="description">{{{ description }}}</p>
+                {{/hasDescription}}
+                <pre class="code-block"><code class="language-nim">{{{ code }}}</code></pre>
+              </div>
+              {{/groups}}
+            </div>
+            {{/procs}}
+          </section>
+          {{/api.freeProcModules}}
         </section>
         {{/is_api_docs}}
 
@@ -541,6 +568,91 @@
       }, 0);
 
       // Sidebar Logic
+      // 0. Persist expanded/collapsed state of sections and types
+      const storageKey = 'api-nav-state:' + location.pathname;
+      let navState = {};
+      try {
+        navState = JSON.parse(localStorage.getItem(storageKey)) || {};
+      } catch (e) {}
+
+      const saveNavState = () => {
+        try {
+          localStorage.setItem(storageKey, JSON.stringify(navState));
+        } catch (e) {}
+      };
+
+      // Collapsible sections (Constants, Enums, modules): the header gets the
+      // same [+]/[-] control as the Types header, and toggles the visibility
+      // of the section's items.
+      const sectionOpeners = {};
+      document.querySelectorAll('.api-nav-header[data-section]').forEach(header => {
+        const section = header.dataset.section;
+        const key = 'section:' + section;
+        const items = document.querySelectorAll('[data-section-item="' + section + '"]');
+        const label = header.textContent.trim();
+        let open = key in navState ? navState[key] : true;
+
+        const render = () => {
+          header.innerHTML = label + ' <span style="float:right; font-family: monospace;">' + (open ? '[-]' : '[+]') + '</span>';
+          items.forEach(li => {
+            li.style.display = open ? '' : 'none';
+          });
+        };
+
+        const setOpen = value => {
+          if (open !== value) {
+            open = value;
+            navState[key] = open;
+            saveNavState();
+            render();
+          }
+        };
+
+        render();
+        header.style.cursor = 'pointer';
+        header.addEventListener('click', () => setOpen(!open));
+        sectionOpeners[section] = () => setOpen(true);
+      });
+
+      // Persist per-type expanded/collapsed state
+      document.querySelectorAll('.api-type-details').forEach(d => {
+        const key = 'type:' + (d.dataset.type || '');
+        if (key in navState) {
+          d.open = navState[key];
+        }
+        d.addEventListener('toggle', () => {
+          navState[key] = d.open;
+          saveNavState();
+        });
+      });
+
+      // If the URL points at a symbol, open its sidebar section and make
+      // sure the link is visible.
+      const revealHash = () => {
+        if (!location.hash) {
+          return;
+        }
+        const links = document.querySelectorAll('.api-nav-content a');
+        for (const link of links) {
+          const href = link.getAttribute('href') || '';
+          if (href === location.hash || href.endsWith(location.hash)) {
+            const item = link.closest('[data-section-item]');
+            if (item && sectionOpeners[item.dataset.sectionItem]) {
+              sectionOpeners[item.dataset.sectionItem]();
+            }
+            let details = link.closest('details');
+            while (details) {
+              details.open = true;
+              details = details.parentElement.closest('details');
+            }
+            link.scrollIntoView({block: 'center'});
+            break;
+          }
+        }
+      };
+      revealHash();
+      window.addEventListener('hashchange', revealHash);
+
       // 1. "TYPES" Header Toggle
       const headers = document.querySelectorAll('.api-nav-header');
       let typesHeader = null;

--- a/docs/book/template.html.mustache
+++ b/docs/book/template.html.mustache
@@ -617,7 +617,17 @@
 
         render();
         header.style.cursor = 'pointer';
-        header.addEventListener('click', () => setOpen(!open));
+        header.addEventListener('click', () => {
+          setOpen(!open);
+          // Module headers also navigate to their section in the content
+          if (header.dataset.anchor) {
+            const target = document.getElementById(header.dataset.anchor);
+            if (target) {
+              target.scrollIntoView();
+              history.replaceState(null, '', '#' + header.dataset.anchor);
+            }
+          }
+        });
         sectionOpeners[section] = () => setOpen(true);
       });
 

--- a/docs/book/template.html.mustache
+++ b/docs/book/template.html.mustache
@@ -627,9 +627,19 @@
       });
 
       // If the URL points at a symbol, open its sidebar section and make
-      // sure the link is visible.
+      // sure the link is visible. Clicks inside the sidebar suppress this —
+      // the user is already looking at the link, and reveal would fight
+      // their expand/collapse.
+      let suppressReveal = false;
+      document.querySelector('.sidebar').addEventListener('click', e => {
+        if (e.target.closest('a')) {
+          suppressReveal = true;
+          setTimeout(() => { suppressReveal = false; }, 100);
+        }
+      });
+
       const revealHash = () => {
-        if (!location.hash) {
+        if (suppressReveal || !location.hash) {
           return;
         }
         const links = document.querySelectorAll('.api-nav-content a');
@@ -645,7 +655,14 @@
               details.open = true;
               details = details.parentElement.closest('details');
             }
-            link.scrollIntoView({block: 'center'});
+            // Only scroll the sidebar if the link isn't already in view
+            const box = document.querySelector('.sidebar-scrollbox') ||
+              document.querySelector('.sidebar');
+            const b = box.getBoundingClientRect();
+            const r = link.getBoundingClientRect();
+            if (r.height === 0 || r.top < b.top || r.bottom > b.bottom) {
+              link.scrollIntoView({block: 'center'});
+            }
             break;
           }
         }
@@ -693,28 +710,15 @@
       }
 
       // 2. Type Item Click Logic
+      // Navigation scrolls the content (default link behavior), and the
+      // type always expands/collapses in the sidebar — no guessing.
       const typeLinks = document.querySelectorAll('.api-type-details > summary > a');
       typeLinks.forEach(link => {
-        link.addEventListener('click', function(e) {
-          // Allow default navigation (scrolling) to happen first
-          // But we need to detect if it actually moved
-          const startScroll = window.scrollY;
-
-          // Let the browser handle the jump
+        link.addEventListener('click', function() {
+          const details = this.closest('details');
+          const wasOpen = details.open;
           setTimeout(() => {
-            const endScroll = window.scrollY;
-            const details = this.closest('details');
-            const userScrolled = Math.abs(endScroll - startScroll) > 5;
-
-            if (!details.open) {
-              // Collapsed -> Expand (always)
-              details.open = true;
-            } else {
-              // Expanded -> Collapse ONLY if we didn't scroll
-              if (!userScrolled) {
-                details.open = false;
-              }
-            }
+            details.open = !wasOpen;
           }, 0);
         });
       });

--- a/docs/book/template.html.mustache
+++ b/docs/book/template.html.mustache
@@ -264,7 +264,7 @@
               <p class="description">{{{ description }}}</p>
               {{/description}}
               <pre class="code-block constant-block"><code class="language-nim">{{{ code }}}</code></pre>
-              <p class="source">Source: <code>{{ module }}</code></p>
+              <p class="source">Source: {{#hasSourceUrl}}<a href="{{ sourceUrl }}"><code>{{ module }}</code></a>{{/hasSourceUrl}}{{^hasSourceUrl}}<code>{{ module }}</code>{{/hasSourceUrl}}</p>
             </article>
             {{/api.constants}}
           </section>
@@ -280,7 +280,7 @@
               <p class="description">{{{ description }}}</p>
               {{/description}}
               <pre class="code-block enum-block"><code class="language-nim">{{{ code }}}</code></pre>
-              <p class="source">Source: <code>{{ module }}</code></p>
+              <p class="source">Source: {{#hasSourceUrl}}<a href="{{ sourceUrl }}"><code>{{ module }}</code></a>{{/hasSourceUrl}}{{^hasSourceUrl}}<code>{{ module }}</code>{{/hasSourceUrl}}</p>
             </article>
             {{/api.enums}}
           </section>
@@ -297,7 +297,7 @@
               <p class="description">{{{ description }}}</p>
               {{/description}}
               <pre class="code-block"><code class="language-nim">{{{ code }}}</code></pre>
-              <p class="source">Source: <code>{{ module }}</code></p>
+              <p class="source">Source: {{#hasSourceUrl}}<a href="{{ sourceUrl }}"><code>{{ module }}</code></a>{{/hasSourceUrl}}{{^hasSourceUrl}}<code>{{ module }}</code>{{/hasSourceUrl}}</p>
               {{/hasType}}
 
               {{#hasStaticProcs}}
@@ -338,6 +338,12 @@
           {{#api.freeProcModules}}
           <section id="{{ anchor }}" class="module-section">
             <h3><a href="#{{ anchor }}"><code>{{ name }}</code></a></h3>
+            {{#hasDescription}}
+            <p class="description">{{{ description }}}</p>
+            {{/hasDescription}}
+            {{#hasSourceUrl}}
+            <p class="source">Source: <a href="{{ sourceUrl }}"><code>{{ module }}</code></a></p>
+            {{/hasSourceUrl}}
             {{#procs}}
             <div class="operation" id="{{ anchor }}">
               <h5><a href="#{{ anchor }}">{{ name }}</a></h5>
@@ -590,7 +596,8 @@
         const key = 'section:' + section;
         const items = document.querySelectorAll('[data-section-item="' + section + '"]');
         const label = header.textContent.trim();
-        let open = key in navState ? navState[key] : true;
+        const defaultOpen = !('collapsed' in header.dataset);
+        let open = key in navState ? navState[key] : defaultOpen;
 
         const render = () => {
           header.innerHTML = label + ' <span style="float:right; font-family: monospace;">' + (open ? '[-]' : '[+]') + '</span>';

--- a/docs/book/templates/ed_toc.html.mustache
+++ b/docs/book/templates/ed_toc.html.mustache
@@ -49,7 +49,7 @@
 
           {{#api.freeProcModules}}
           <li class="chapter-item">
-            <div class="api-nav-header" data-section="module-{{ name }}" data-collapsed>{{ name }}</div>
+            <div class="api-nav-header" data-section="module-{{ name }}" data-anchor="{{ anchor }}" data-collapsed>{{ name }}</div>
           </li>
           {{#procs}}
           <li class="chapter-item api-nav-item" data-section-item="module-{{ module }}"><a href="{{#is_readme}}ed_api.html{{/is_readme}}#{{ anchor }}">{{ name }}</a></li>

--- a/docs/book/templates/ed_toc.html.mustache
+++ b/docs/book/templates/ed_toc.html.mustache
@@ -49,7 +49,7 @@
 
           {{#api.freeProcModules}}
           <li class="chapter-item">
-            <div class="api-nav-header" data-section="module-{{ name }}">{{ name }}</div>
+            <div class="api-nav-header" data-section="module-{{ name }}" data-collapsed>{{ name }}</div>
           </li>
           {{#procs}}
           <li class="chapter-item api-nav-item" data-section-item="module-{{ module }}"><a href="{{#is_readme}}ed_api.html{{/is_readme}}#{{ anchor }}">{{ name }}</a></li>

--- a/docs/book/templates/enu_toc.html.mustache
+++ b/docs/book/templates/enu_toc.html.mustache
@@ -49,7 +49,7 @@
 
           {{#api.freeProcModules}}
           <li class="chapter-item">
-            <div class="api-nav-header" data-section="module-{{ name }}">{{ name }}</div>
+            <div class="api-nav-header" data-section="module-{{ name }}" data-collapsed>{{ name }}</div>
           </li>
           {{#procs}}
           <li class="chapter-item api-nav-item" data-section-item="module-{{ module }}"><a href="#{{ anchor }}">{{ name }}</a></li>

--- a/docs/book/templates/enu_toc.html.mustache
+++ b/docs/book/templates/enu_toc.html.mustache
@@ -49,7 +49,7 @@
 
           {{#api.freeProcModules}}
           <li class="chapter-item">
-            <div class="api-nav-header" data-section="module-{{ name }}" data-collapsed>{{ name }}</div>
+            <div class="api-nav-header" data-section="module-{{ name }}" data-anchor="{{ anchor }}" data-collapsed>{{ name }}</div>
           </li>
           {{#procs}}
           <li class="chapter-item api-nav-item" data-section-item="module-{{ module }}"><a href="#{{ anchor }}">{{ name }}</a></li>

--- a/docs/book/templates/enu_toc.html.mustache
+++ b/docs/book/templates/enu_toc.html.mustache
@@ -1,16 +1,16 @@
     <ol class="chapter">
       <li class="chapter-item expanded">
-        <a href="ed_readme.html"{{#is_readme}} class="active"{{/is_readme}} tabindex="0"><strong aria-hidden="true">1.</strong> README</a>
+        <a href="{{ path_to_root }}intro.html" tabindex="0">← Documentation</a>
       </li>
       <li class="chapter-item expanded">
-        <a href="ed_api.html"{{^is_readme}} class="active"{{/is_readme}} tabindex="0"><strong aria-hidden="true">2.</strong> API Reference</a>
+        <a href="enu_api.html" class="active" tabindex="0">API Reference</a>
         <ol class="section api-nav-content">
           {{#api.hasConstants}}
           <li class="chapter-item">
             <div class="api-nav-header" data-section="constants">Constants</div>
           </li>
           {{#api.constants}}
-          <li class="chapter-item api-nav-item" data-section-item="constants"><a href="{{#is_readme}}ed_api.html{{/is_readme}}#{{ anchor }}">{{ name }}</a></li>
+          <li class="chapter-item api-nav-item" data-section-item="constants"><a href="#{{ anchor }}">{{ name }}</a></li>
           {{/api.constants}}
           {{/api.hasConstants}}
 
@@ -19,7 +19,7 @@
             <div class="api-nav-header" data-section="enums">Enums</div>
           </li>
           {{#api.enums}}
-          <li class="chapter-item api-nav-item" data-section-item="enums"><a href="{{#is_readme}}ed_api.html{{/is_readme}}#{{ anchor }}">{{ name }}</a></li>
+          <li class="chapter-item api-nav-item" data-section-item="enums"><a href="#{{ anchor }}">{{ name }}</a></li>
           {{/api.enums}}
           {{/api.hasEnums}}
 
@@ -30,20 +30,20 @@
           {{#hasOps}}
           <li class="chapter-item api-nav-item">
             <details class="api-type-details" data-type="{{ name }}">
-              <summary><a href="{{#is_readme}}ed_api.html{{/is_readme}}#{{ anchor }}">{{ name }}</a></summary>
+              <summary><a href="#{{ anchor }}">{{ name }}</a></summary>
               <ol class="section">
                 {{#staticProcNames}}
-                <li class="chapter-item"><a href="{{#is_readme}}ed_api.html{{/is_readme}}#{{ anchor }}">{{ name }}</a></li>
+                <li class="chapter-item"><a href="#{{ anchor }}">{{ name }}</a></li>
                 {{/staticProcNames}}
                 {{#procNames}}
-                <li class="chapter-item"><a href="{{#is_readme}}ed_api.html{{/is_readme}}#{{ anchor }}">{{ name }}</a></li>
+                <li class="chapter-item"><a href="#{{ anchor }}">{{ name }}</a></li>
                 {{/procNames}}
               </ol>
             </details>
           </li>
           {{/hasOps}}
           {{^hasOps}}
-          <li class="chapter-item api-nav-item"><a href="{{#is_readme}}ed_api.html{{/is_readme}}#{{ anchor }}">{{ name }}</a></li>
+          <li class="chapter-item api-nav-item"><a href="#{{ anchor }}">{{ name }}</a></li>
           {{/hasOps}}
           {{/api.types}}
 
@@ -52,7 +52,7 @@
             <div class="api-nav-header" data-section="module-{{ name }}">{{ name }}</div>
           </li>
           {{#procs}}
-          <li class="chapter-item api-nav-item" data-section-item="module-{{ module }}"><a href="{{#is_readme}}ed_api.html{{/is_readme}}#{{ anchor }}">{{ name }}</a></li>
+          <li class="chapter-item api-nav-item" data-section-item="module-{{ module }}"><a href="#{{ anchor }}">{{ name }}</a></li>
           {{/procs}}
           {{/api.freeProcModules}}
         </ol>

--- a/docs/book/todo.md
+++ b/docs/book/todo.md
@@ -21,11 +21,6 @@ Enu needs a proper inventory, menus, and a way to move objects.
 
 Write games, and add features to support them.
 
-### Forward Arrow
-
-Show an arrow pointing forward from the current draw point, so it 
-will always be clear which way `forward` goes.
-
 ### Pivot point
 
 Currently it isn't possible to change the pivot point for a unit, and the 
@@ -41,8 +36,8 @@ A REPL could be used to experiment, run commands, and change settings.
 
 ### Additional Platforms and App Stores
 
-Shortly after 0.2 Enu will be made available on the Mac App Store and Steam. iOS
-and iPadOS will likely be next, with Android and VR platforms following later.
+Enu will be made available on the Mac App Store and Steam. iOS and iPadOS will
+likely be next, with Android and VR platforms following later.
 
 ### Graphics
 

--- a/docs/enuib.nim
+++ b/docs/enuib.nim
@@ -9,6 +9,7 @@ export api_docs
 
 const document* = hl_html static_read("./book/template.html.mustache")
 const ed_toc* = hl_html static_read("./book/templates/ed_toc.html.mustache")
+const enu_toc* = hl_html static_read("./book/templates/enu_toc.html.mustache")
 const use_api_document = false
 
 proc use_enu*(doc: var NbDoc) =
@@ -60,11 +61,19 @@ proc use_enu*(doc: var NbDoc) =
   doc.context["title"] = this_entry.title & " - " & book.title
 
 proc use_api_docs*(doc: var NbDoc) =
-  ## Theme for API documentation pages
+  ## Theme for Ed API documentation pages
   ## Uses the unified template but overrides the TOC with the API sidebar
   use_enu(doc)
   doc.partials["toc"] = ed_toc
   doc.context["is_api_docs"] = true
+  doc.context["api_title"] = "Ed API Reference"
+
+proc use_enu_api_docs*(doc: var NbDoc) =
+  ## Theme for the Enu scripting API reference page
+  use_enu(doc)
+  doc.partials["toc"] = enu_toc
+  doc.context["is_api_docs"] = true
+  doc.context["api_title"] = "Enu API Reference"
 
 proc use_ed_readme*(doc: var NbDoc) =
   ## Theme for Ed README page

--- a/share/vmlib/enu/base_bridge.nim
+++ b/share/vmlib/enu/base_bridge.nim
@@ -19,64 +19,148 @@ proc sees_impl*(self: Unit, target: Unit, less_than = 100.0): bool =
 
 bridged_to_host:
   proc now_seconds*(): float
+    ## Seconds since Enu started. `now()` is usually nicer.
+
   proc write_stack_trace*()
   proc id*(self: Unit): string
+    ## The unit's name, like "bot_1729". Every unit has a different one.
+
   proc position*(self: Unit): Vector3
+    ## Where the unit is. Assign to it to teleport:
+    ## `position = player.position` (zap!).
+
   proc local_position*(self: Unit): Vector3
+    ## Where the unit is compared to its parent, instead of the world.
+
   proc start_position*(self: Unit): Vector3
+    ## Where the unit starts when the level loads. Assigning moves the
+    ## start point, and that sticks around after a reload.
+
   proc speed*(self: Unit): float
+    ## How fast the unit moves or builds. `1` is normal, bigger is
+    ## faster, and `0` means "all at once" for building.
+
   proc `speed=`*(self: Unit, speed: float)
   proc scale*(self: Unit): float
+    ## How big the unit is. `1` is normal size, `2` is double, `0.5` is
+    ## half. Careful going tiny — it's easy to lose things.
+
   proc `scale=`*(self: Unit, scale: float)
   proc glow*(self: Unit): float
+    ## How much the unit glows. `0` is no glow; crank it up to make
+    ## something impossible to miss.
+
   proc `glow=`*(self: Unit, energy: float)
   proc global*(self: Unit): bool
+    ## Whether the unit lives in world space (`true`) or moves around
+    ## with its parent (`false`).
+
   proc `global=`*(self: Unit, global: bool)
   proc rotation*(self: Unit): float
+    ## Which way the unit is facing, in degrees. Assign to spin it
+    ## around: `rotation = 180` does an about-face.
+
   proc `rotation=`*(self: Unit, degrees: float)
   proc hit*(self: Unit, node: Unit): bool
   proc `velocity=`*(self: Unit, velocity: Vector3)
   proc velocity*(self: Unit): Vector3
+    ## How fast (and which way) the unit is moving right now.
+
   proc color*(self: Unit): Colors
+    ## The unit's color. For a Build this is the drawing color — blocks
+    ## you draw after changing it use the new color.
+
   proc `color=`*(self: Unit, color: Colors)
   proc show*(self: Unit): bool
+    ## Whether the unit is visible. `show = false` makes it vanish.
+    ## It's still there. It's just being sneaky.
+
   proc `show=`*(self: Unit, value: bool)
   proc frame_created*(self: Unit): int
+    ## The frame number when the unit was created.
+
   proc lock*(self: Unit): bool
+    ## Locked units can't be edited in the world with the mouse. Good
+    ## for finished builds you don't want to nudge by accident.
+
   proc `lock=`*(self: Unit, value: bool)
   proc reset*(self: Unit, clear = false)
+    ## Send the unit back to its start position, rotation and scale.
+    ## With `clear = true`, a Build also forgets its drawn blocks.
+
   proc adopt*(self: Unit, unit: Unit)
+    ## Make another unit this unit's child, so it moves when this one
+    ## moves.
+
   proc release*(self: Unit)
+    ## Let a child unit go free. The opposite of `adopt`.
+
   proc press_action*(name: string)
+    ## Pretend a button was pressed, like "jump". `release_action`
+    ## lets it go. Yes, this means you can prank the player.
+
   proc release_action*(name: string)
   proc load_level*(level: string, world = "")
+    ## Switch to a different level.
+
   proc reset_level*()
+    ## Restart the current level from scratch.
+
   proc level_name*(): string
+    ## The name of the current level.
+
   proc world_name*(): string
+    ## The name of the current world.
+
   proc current_colliders*(self: Unit, name: string): seq[Unit]
   proc all_builds*(): seq[Build]
+    ## Every build in the world. `Build.all` is the fancier way.
+
   proc all_bots*(): seq[Bot]
+    ## Every bot in the world. `Bot.all` is the fancier way.
+
   proc all_signs*(): seq[Sign]
+    ## Every sign in the world.
+
   proc all_players*(): seq[Player]
+    ## Everyone playing right now.
+
   proc all_units*(): seq[Unit]
+    ## Every unit in the world — builds, bots, signs and players.
+
   proc find_voxel_overlaps*(limit: int = 50): string
   proc units_in_box*(
     x1: float, y1: float, z1: float, x2: float, y2: float, z2: float
   ): seq[Unit]
+    ## Every unit inside the box between two corners.
 
   proc floor_at*(x: float, z: float): int
+    ## The height of the ground at a spot — the y of the highest solid
+    ## block, plus 1.
 
   proc clear_box*(
     x1: float, y1: float, z1: float, x2: float, y2: float, z2: float
   ): bool
+    ## Erase every block inside the box between two corners.
 
   proc bounds*(self: Unit): WorldBox
+    ## The invisible box around the unit and everything it's made of.
+
   proc overlaps*(a: Unit, b: Unit): bool
+    ## `true` if two units' boxes overlap.
+
   proc units_overlapping*(box: WorldBox): seq[Unit]
+    ## Every unit whose box overlaps this one.
+
   proc box_is_free*(box: WorldBox): bool
+    ## `true` if nothing is in the box — handy for checking a spot
+    ## before building there.
+
   proc bounds_at*(
     self: Build, position: Vector3, rotation: float = 0.0, scale: float = 0.0
   ): WorldBox
+    ## The box this build *would* take up at a different position,
+    ## rotation or scale. Check before you leap.
 
   proc added_units*(): seq[Unit]
   proc register_template_node*(self: Unit, name: string)

--- a/share/vmlib/enu/base_bridge.nim
+++ b/share/vmlib/enu/base_bridge.nim
@@ -1,3 +1,7 @@
+## Properties and queries that every unit has, like `position`, `speed`,
+## `color` and `scale`. These commands cross over into the Enu engine
+## itself.
+
 import types, vm_bridge_utils
 
 # NOTE: overridden by ScriptController. Only for tests.

--- a/share/vmlib/enu/bots.nim
+++ b/share/vmlib/enu/bots.nim
@@ -1,16 +1,22 @@
 import std/[strutils, math]
-import types, base_api, vm_bridge_utils
+import core, vm_bridge_utils
 
 bridged_to_host:
   proc play*(self: Bot, animation_name: string)
+    ## Play an animation by name, like `play "wave"`. Play `""` to
+    ## stop.
 
 proc walk*(self: Bot) =
+  ## Walking speed. The same as `speed = 1`.
   self.speed = 1.0
 
 proc run*(self: Bot) =
+  ## Running speed. The same as `speed = 5`.
   self.speed = 5.0
 
 proc go_home*(self: Bot) =
+  ## Head back to the start position by turning around and walking
+  ## there. Also resets scale, glow, and hides any open sign.
   if ?self.sign:
     self.sign.show = false
   self.scale = 1

--- a/share/vmlib/enu/bots_private.nim
+++ b/share/vmlib/enu/bots_private.nim
@@ -1,4 +1,4 @@
-import types, base_api, bots
+import core, bots
 
 proc play*(animation_name: string) =
   Bot(active_unit()).play(animation_name)

--- a/share/vmlib/enu/builds.nim
+++ b/share/vmlib/enu/builds.nim
@@ -1,4 +1,7 @@
 import std/[strutils, math]
+## Commands for building with blocks: shapes like `box`, `ball`, `wall`
+## and `floor`, plus turtle controls like `drawing` and `save`/`restore`.
+
 import core, vm_bridge_utils
 
 type BoxPivot* = enum

--- a/share/vmlib/enu/builds.nim
+++ b/share/vmlib/enu/builds.nim
@@ -1,5 +1,5 @@
 import std/[strutils, math]
-import types, base_api, vm_bridge_utils
+import core, vm_bridge_utils
 
 type BoxPivot* = enum
   corner
@@ -8,14 +8,29 @@ type BoxPivot* = enum
 
 bridged_to_host:
   proc drawing*(self: Build): bool
+    ## Whether the turtle draws blocks as it moves. `drawing = false`
+    ## lets you sneak the turtle somewhere without leaving a trail.
+
   proc `drawing=`*(self: Build, drawing: bool)
   proc initial_position(self: Build): Vector3
   proc save*(self: Build, name = "default")
+    ## Remember the turtle's position, direction, color and drawing
+    ## state, so `restore` can jump back later. Give it a name to keep
+    ## more than one: `save "doorway"`.
+
   proc restore*(self: Build, name = "default")
+    ## Jump the turtle back to a spot remembered with `save`.
+
   proc draw_position*(self: Build): Vector3
+    ## Where the turtle is. Assign a position (or a unit) to teleport
+    ## the turtle there and keep drawing.
+
   proc `draw_position=`*(self: Build, value: Vector3)
   proc has_block_at*(position: Vector3): bool
+    ## `true` if this build has a block at that spot.
+
   proc block_color_at*(position: Vector3): Colors
+    ## The color of the block at that spot.
   proc begin_asap*(self: Build)
   proc end_asap*(self: Build)
   proc draw_voxel*(self: Build, position: Vector3, color: Colors)
@@ -79,10 +94,13 @@ bridged_to_host:
     ## to leave the turtle at the far end of the shape.
 
 proc pending_block_updates*(self: Unit): int =
+  ## How many block changes are still being worked on. `0` means
+  ## everything you've drawn is actually on screen.
   pending_block_updates_get(self)
 
 template asap*(body: untyped) =
-  ## Execute build commands instantly without incremental updates.
+  ## Draw everything inside the block instantly, instead of block by
+  ## block. Like `speed = ASAP`, but it puts the speed back afterward.
   let self = Build(active_unit())
   let prev_speed = self.speed
   self.speed = ASAP
@@ -95,6 +113,8 @@ proc `draw_position=`*(self: Build, unit: Unit) =
   self.draw_position = unit.position
 
 proc go_home*(self: Build) =
+  ## Head back to the start position by going forward, left, and down
+  ## the right amounts. Also resets rotation, scale and glow.
   self.rotation = 0
   self.scale = 1
   self.glow = 0
@@ -103,17 +123,18 @@ proc go_home*(self: Build) =
   self.down self.position.y - self.start_position.y, 2
 
 proc fill_square*(self: Build, length = 1) =
+  ## Draw a filled square, `length` blocks on a side.
   for l in 0 .. length:
     for i in 0 .. 3:
       self.forward(length - l, 2)
       self.right(1, 2)
 
 proc place*(self: Build, x, y, z: int, color = self.color) =
-  ## Place a single block at local integer coordinates.
+  ## Put a single block at exact coordinates, without moving the
+  ## turtle. `place 3, 0, 5, red`.
   self.draw_voxel((x.float, y.float, z.float), color)
 
 template place*(x, y, z: int, color = active_unit().color) =
-  ## Place a single block at local integer coords in a build script.
   Build(active_unit()).place(x, y, z, color)
 
 # === Turtle-aware shape primitives ==================================
@@ -138,7 +159,11 @@ proc box*(
     fill = true,
     pivot: BoxPivot = corner,
 ) =
-  ## At the turtle's current transform.
+  ## Draw a box. `box 5, 3, 8` makes one 5 wide, 3 tall and 8 deep,
+  ## starting where the turtle is and facing the way it faces. Or draw
+  ## it somewhere else with `at = vec3(...)`, or between two corners
+  ## with `box corner1, corner2`. `fill = false` makes it hollow, like
+  ## a room.
   self.box_impl(
     width, height, depth, color, fill, ord(pivot), vec3(0, 0, 0), 0.0, true
   )
@@ -152,14 +177,14 @@ proc box*(
     fill = true,
     pivot: BoxPivot = corner,
 ) =
-  ## At an explicit unit-local coord. Optional yaw rotation.
+  # At an explicit unit-local coord. Optional yaw rotation.
   self.box_impl(
     width, height, depth, color, fill, ord(pivot), at, rotation, false
   )
 
 proc box*(self: Build, at, to: Vector3, color = self.color, fill = true) =
-  ## Axis-aligned corner-to-corner, inclusive of both corners. Corner
-  ## order doesn't matter (min/max normalised).
+  # Axis-aligned corner-to-corner, inclusive of both corners. Corner
+  # order doesn't matter (min/max normalised).
   let lo = vec3(min(at.x, to.x), min(at.y, to.y), min(at.z, to.z))
   let hi = vec3(max(at.x, to.x), max(at.y, to.y), max(at.z, to.z))
   let w = int(hi.x - lo.x) + 1
@@ -201,6 +226,9 @@ template box*(at, to: Vector3, color = active_unit().color, fill = true) =
 # Int and float sizes both accepted.
 
 proc sphere*(self: Build, size: float, color = self.color, fill = true) =
+  ## Draw a sphere, `size` blocks across, centred on the turtle. Draw
+  ## it somewhere else with `at = vec3(...)`. `ball` means the same
+  ## thing and is more fun to say.
   self.sphere_impl(size, color, fill, vec3(0, 0, 0), true)
 
 proc sphere*(
@@ -230,6 +258,7 @@ template sphere*(
 # args as `sphere`; color defaults to the current turtle color.
 
 template ball*(size: int | float, color = active_unit().color, fill = true) =
+  ## A sphere, but friendlier. Same as `sphere`.
   Build(active_unit()).sphere(size, color, fill)
 
 template ball*(
@@ -245,6 +274,9 @@ template ball*(
 proc cylinder*(
     self: Build, size: float, height: int, color = self.color, fill = true
 ) =
+  ## Draw a cylinder, `size` blocks across and `height` blocks tall,
+  ## standing on the turtle's spot. Draw it somewhere else with
+  ## `at = vec3(...)`. `can` means the same thing.
   self.cylinder_impl(size, height, color, fill, vec3(0, 0, 0), true)
 
 proc cylinder*(
@@ -294,6 +326,7 @@ template cylinder*(
 template can*(
     size: int | float, height: int, color = active_unit().color, fill = true
 ) =
+  ## A cylinder, but friendlier. Same as `cylinder`.
   Build(active_unit()).cylinder(size, height, color, fill)
 
 template can*(
@@ -310,11 +343,10 @@ template can*(
 template wall*(
     length: int, height: int = 4, color: Colors = active_unit().color
 ) =
-  ## A `length`-long, `height`-tall, 1-thick wall extending along the
-  ## turtle's local forward. Leaves the turtle at the wall's last
-  ## voxel (advance length - 1), so `wall N; turn right; wall M`
-  ## traces a closed N×M corner — the two walls share the corner
-  ## voxel instead of leaving a 1-cell gap.
+  ## Draw a wall, `length` blocks long and `height` tall (4 unless you
+  ## say), heading the way the turtle faces. The turtle ends up at the
+  ## far end, so `wall 10; turn right; wall 10` makes a perfect corner.
+  ## Four of those and you've got yourself a fort.
   let me = Build(active_unit())
   me.box(1, height, length, color)
   if length > 1:
@@ -323,9 +355,9 @@ template wall*(
 template floor*(
     length: int, width: int = length, color: Colors = active_unit().color
 ) =
-  ## A `length`-deep, `width`-wide, 1-thick slab in the turtle's
-  ## horizontal plane. Leaves the turtle at the slab's far edge
-  ## (advance length - 1), matching `wall`.
+  ## Draw a flat slab, `length` deep and `width` wide (square unless
+  ## you say). Like `wall`, the turtle ends up at the far edge, ready
+  ## for whatever you're building next.
   let me = Build(active_unit())
   me.box(width, 1, length, color)
   if length > 1:

--- a/share/vmlib/enu/builds_private.nim
+++ b/share/vmlib/enu/builds_private.nim
@@ -1,4 +1,4 @@
-import types, base_api, builds, vm_bridge_utils
+import core, builds, vm_bridge_utils
 
 bridged_to_host:
   proc place_block*(self: Build, position: Vector3, color: Colors)

--- a/share/vmlib/enu/class_macros.nim
+++ b/share/vmlib/enu/class_macros.nim
@@ -1,6 +1,5 @@
 import std/[macros, strutils, sequtils, os]
-import types
-import base_api, macro_helpers, base_bridge_private
+import core, macro_helpers, base_bridge_private
 
 template with_line_info(node, source: NimNode): NimNode =
   let n = node

--- a/share/vmlib/enu/core.nim
+++ b/share/vmlib/enu/core.nim
@@ -1,3 +1,6 @@
+## The heart of the Enu API: moving, turning, building, random numbers,
+## timers, and the other everyday commands that every script can use.
+
 import system except echo
 import
   std/[

--- a/share/vmlib/enu/core.nim
+++ b/share/vmlib/enu/core.nim
@@ -4,40 +4,55 @@ import
     strformat, math, importutils, strutils, options, sets, sequtils, algorithm
   ]
 import random as rnd except rand
-import types, state_machine, base_bridge, base_bridge_private
+import types, vectors, base_bridge, base_bridge_private
 
-export base_bridge
+export types, vectors, base_bridge
 export strutils
-export Timestamp, Duration
+
+proc init*[T: Exception](
+    kind: type[T], message: string, parent: ref Exception = nil
+): ref Exception =
+  ## Make an error you can `raise`. For example,
+  ## `raise ValueError.init("that's not going to work")`.
+  (ref kind)(msg: message, parent: parent)
 
 proc now*(): Timestamp =
-  ## Returns the current time as a Timestamp.
-  ## Use with subtraction to measure elapsed time:
+  ## The time right now. Subtract two of these to see how much time
+  ## passed:
   ##   let start = now()
-  ##   # ... do work ...
-  ##   let elapsed = now() - start
-  ##   echo "Took ", elapsed
-  init_timestamp(now_seconds())
+  ##   # ... do something slow ...
+  ##   echo "Took ", now() - start
+  Timestamp.init(now_seconds())
 
 var state_init_callbacks: seq[proc()] = @[]
 
 proc register_state_init*(callback: proc()) =
+  ## Used by Enu while a level loads. You won't need this in a script.
   state_init_callbacks.add(callback)
 
 proc initialize_state*() =
+  ## Used by Enu while a level loads. You won't need this in a script.
   for callback in state_init_callbacks:
     callback()
 
 proc echo*(args: varargs[string, `$`]) =
+  ## Print something to the console. The best way to spy on what your
+  ## script is up to: `echo "score is ", score`.
   echo_console(args.join)
 
 proc quit*(code = 0, msg = "") =
+  ## Stop the script.
   exit(code, msg)
 
 proc `position=`*(self: Unit, position: Vector3) =
+  ## Teleport the unit. No walking, no animation — it's just there now.
+  ## You can also assign another unit to teleport to wherever it is:
+  ## `me.position = player.position`, or just `me.position = player`.
   self.position_set(position)
 
 proc apply_position*(self: Unit, position: Vector3) =
+  ## Teleport the unit, unless the position is unset. Used by Enu
+  ## internally.
   if position.x != float.high:
     self.position = position
 
@@ -45,34 +60,41 @@ proc `position=`*(self: Unit, unit: Unit) =
   self.position_set(unit.position)
 
 proc `start_position=`*(self: Unit, position: Vector3) =
-  ## Update the unit's spawn position. Persists across reload (unlike `position=`,
-  ## which only moves the live transform).
+  ## Change where the unit starts. Unlike `position=`, this is
+  ## remembered when the level reloads.
   self.start_position_set(position)
 
 proc delete*(self: Unit) =
-  ## Remove the unit from the level and delete its on-disk script + data
-  ## directory. Distinct from `destroy`, which only tears down the in-memory
-  ## instance. Cannot be undone.
+  ## Remove the unit from the level, along with its script and saved
+  ## data. There's no undo, so be really sure.
   base_bridge_private.delete(self)
 
 proc keep_alive*() =
-  ## Reset the per-script execution timeout. For long-running non-yielding
-  ## loops that need more than the default ~2s budget. Call periodically.
+  ## Enu stops scripts that grind away for ~2 seconds without pausing,
+  ## in case they're stuck. If your loop really does need that long,
+  ## call this now and then to say "not stuck, just busy!"
   base_bridge_private.keep_alive()
 
 proc go*(self: Unit, position: Unit | Vector3) =
+  ## Teleport the unit to a position, or to another unit. The same as
+  ## setting `position=`.
   self.position = position
 
 proc `seed=`*(self: Unit, seed: int) =
+  ## Random numbers in Enu follow a secret recipe called a seed. Give
+  ## two units the same seed and they'll roll the same "random" numbers
+  ## in the same order. By default every unit gets a different seed.
   private_access Unit
   self.rng = init_rand(seed)
   self.seed = seed
 
 proc seed*(self: Unit): int =
+  ## The unit's random seed. See `seed=`.
   private_access Unit
   self.seed
 
 proc bounce*(me: Player, power = 1.0) =
+  ## Launch the player into the air. More power, more air.
   me.velocity = me.velocity + UP * power * 30
 
 template wait(body: untyped) =
@@ -84,9 +106,17 @@ template wait(body: untyped) =
     self.yield_script()
 
 proc sleep*(seconds = 0.0) =
+  ## Do nothing for this many seconds. With no argument (or 0), naps
+  ## for up to half a second, but wakes up early if something bumps
+  ## into the unit — perfect for a loop that mostly waits around.
   wait sleep_impl(seconds)
 
 proc forward*(self: Unit, steps: float, move_mode: int) =
+  ## Go forward this many blocks (1 if you don't say). In `build` mode
+  ## the turtle draws blocks as it goes; in `move` mode the whole unit
+  ## moves. You can also pass a spot like `home`: `forward home` goes
+  ## forward until you're even with it, and `forward home + 2` goes 2
+  ## blocks past.
   wait self.begin_move(FORWARD, steps, move_mode)
 
 template forward*(self: Unit, steps = 1.0) =
@@ -94,6 +124,7 @@ template forward*(self: Unit, steps = 1.0) =
   wait self.begin_move(FORWARD, steps, move_mode)
 
 proc back*(self: Unit, steps: float, move_mode: int) =
+  ## Like `forward`, but backward.
   wait self.begin_move(BACK, steps, move_mode)
 
 template back*(self: Unit, steps = 1.0) =
@@ -101,6 +132,8 @@ template back*(self: Unit, steps = 1.0) =
   wait self.begin_move(BACK, steps, move_mode)
 
 proc left*(self: Unit, steps: float, move_mode: int) =
+  ## Go left this many blocks (1 if you don't say). Slides sideways —
+  ## no turning.
   wait self.begin_move(LEFT, steps, move_mode)
 
 template left*(self: Unit, steps = 1.0) =
@@ -108,6 +141,8 @@ template left*(self: Unit, steps = 1.0) =
   wait self.begin_move(LEFT, steps, move_mode)
 
 proc right*(self: Unit, steps: float, move_mode: int) =
+  ## Go right this many blocks (1 if you don't say). Slides sideways —
+  ## no turning.
   wait self.begin_move(RIGHT, steps, move_mode)
 
 template right*(self: Unit, steps = 1.0) =
@@ -115,6 +150,7 @@ template right*(self: Unit, steps = 1.0) =
   wait self.begin_move(RIGHT, steps, move_mode)
 
 proc up*(self: Unit, steps: float, move_mode: int) =
+  ## Go up this many blocks (1 if you don't say).
   wait self.begin_move(UP, steps, move_mode)
 
 template up*(self: Unit, steps = 1.0) =
@@ -122,6 +158,7 @@ template up*(self: Unit, steps = 1.0) =
   wait self.begin_move(UP, steps, move_mode)
 
 proc down*(self: Unit, steps: float, move_mode: int) =
+  ## Go down this many blocks (1 if you don't say).
   wait self.begin_move(DOWN, steps, move_mode)
 
 template down*(self: Unit, steps = 1.0) =
@@ -129,64 +166,89 @@ template down*(self: Unit, steps = 1.0) =
   wait self.begin_move(DOWN, steps, move_mode)
 
 template l*(self: Unit, steps = 1.0) =
+  ## Shorthand for `left`.
   self.left(steps)
 
 template r*(self: Unit, steps = 1.0) =
+  ## Shorthand for `right`.
   self.right(steps)
 
 template u*(self: Unit, steps = 1.0) =
+  ## Shorthand for `up`.
   self.up(steps)
 
 template d*(self: Unit, steps = 1.0) =
+  ## Shorthand for `down`.
   self.down(steps)
 
 template f*(self: Unit, steps = 1.0) =
+  ## Shorthand for `forward`.
   self.forward(steps)
 
 template b*(self: Unit, steps = 1.0) =
+  ## Shorthand for `back`.
   self.back(steps)
 
 template forward*(steps = 1.0) =
+  ## Go forward this many blocks (1 if you don't say). In `build` mode
+  ## the turtle draws blocks as it goes; in `move` mode the whole unit
+  ## moves. `f` is the short version.
   enu_target.forward(steps)
 
 template back*(steps = 1.0) =
+  ## Like `forward`, but backward. `b` for short.
   enu_target.back(steps)
 
 template left*(steps = 1.0) =
+  ## Go left this many blocks (1 if you don't say). Slides sideways —
+  ## no turning. `l` for short.
   enu_target.left(steps)
 
 template right*(steps = 1.0) =
+  ## Go right this many blocks (1 if you don't say). Slides sideways —
+  ## no turning. `r` for short.
   enu_target.right(steps)
 
 template up*(steps = 1.0) =
+  ## Go up this many blocks (1 if you don't say). `u` for short.
   enu_target.up(steps)
 
 template down*(steps = 1.0) =
+  ## Go down this many blocks (1 if you don't say). `d` for short.
   enu_target.down(steps)
 
 template l*(steps = 1.0) =
+  ## Shorthand for `left`.
   enu_target.left(steps)
 
 template r*(steps = 1.0) =
+  ## Shorthand for `right`.
   enu_target.right(steps)
 
 template u*(steps = 1.0) =
+  ## Shorthand for `up`.
   enu_target.up(steps)
 
 template d*(steps = 1.0) =
+  ## Shorthand for `down`.
   enu_target.down(steps)
 
 template f*(steps = 1.0) =
+  ## Shorthand for `forward`.
   enu_target.forward(steps)
 
 template b*(steps = 1.0) =
+  ## Shorthand for `back`.
   enu_target.back(steps)
 
 template see*(target: Unit, less_than = 100.0): bool =
+  ## `true` if this unit can see the target: nothing solid in the way,
+  ## and it's closer than `less_than` (100 blocks unless you say
+  ## otherwise). `sees` works too, so `if me.sees player:` reads nicely.
   enu_target.see(target, less_than)
 
-## alias of `see`
 template sees*(target: Unit, less_than = 100.0): bool =
+  ## Alias of `see`.
   enu_target.see(target, less_than)
 
 proc sees*(self: Unit, target: Unit, less_than = 100.0): bool =
@@ -271,9 +333,13 @@ type NegativeNode = ref object
   node: Unit
 
 proc `-`*(node: Unit): NegativeNode =
+  ## A minus sign in front of a unit means "away from it".
+  ## `turn -player` turns your back on the player. Rude, but allowed.
   NegativeNode(node: node)
 
 proc angle_to*(self: Unit, position: Vector3): float =
+  ## How many degrees this unit would have to turn to face a position
+  ## (or another unit).
   let
     p1 = self.position
     d = (p1 - position).normalized()
@@ -295,6 +361,13 @@ proc vec3(direction: Directions): Vector3 =
     of Directions.down, Directions.d: DOWN
 
 proc turn*(self: Unit, direction: Directions, degrees = 90.0, move_mode: int) =
+  ## Turn the unit (or the drawing turtle). You can turn:
+  ## - a direction: `turn left`, or `turn left, 45` for 45 degrees
+  ## - a number of degrees: `turn 90` (positive turns right,
+  ##   negative turns left)
+  ## - toward something: `turn player`
+  ## - away from something: `turn -player`
+  ## `t` is the short version.
   let dir = vec3(direction)
   if dir in [BACK, FORWARD]:
     raise IndexDefect.init("You can't turn forward or back")
@@ -314,10 +387,18 @@ template turn*(self: Unit, direction: Directions, degrees = 90.0) =
   wait turn(self, direction, degrees, move_mode)
 
 template turn*(direction: Directions, degrees = 90.0) =
+  ## Turn the unit (or the drawing turtle). You can turn:
+  ## - a direction: `turn left`, or `turn left, 45` for 45 degrees
+  ## - a number of degrees: `turn 90` (positive turns right,
+  ##   negative turns left)
+  ## - toward something: `turn player`
+  ## - away from something: `turn -player`
+  ## `t` is the short version.
   mixin wait
   wait enu_target.turn(direction, degrees, move_mode)
 
 template t*(direction: Directions, degrees = 90.0) =
+  ## Shorthand for `turn`.
   turn direction, degrees
 
 template turn*(degrees: float) =
@@ -335,6 +416,9 @@ template t*(self: Unit, degrees: float) =
   turn self, degrees
 
 proc lean*(self: Unit, direction: Directions, degrees = 90.0, move_mode: int) =
+  ## Tip the unit (or the drawing turtle) forward, back, left or
+  ## right. Like `turn`, but instead of spinning like a top, you tilt —
+  ## which lets the turtle draw up and down walls or loop-the-loops.
   let dir = vec3(direction)
   if dir in [UP, DOWN]:
     raise IndexDefect.init("You can't lean up or down")
@@ -353,6 +437,9 @@ template lean*(self: Unit, direction: Directions, degrees = 90.0) =
   wait lean(self, direction, degrees, move_mode)
 
 template lean*(direction: Directions, degrees = 90.0) =
+  ## Tip the unit (or the drawing turtle) forward, back, left or
+  ## right. Like `turn`, but instead of spinning like a top, you tilt —
+  ## which lets the turtle draw up and down walls or loop-the-loops.
   mixin wait
   wait enu_target.lean(direction, degrees, move_mode)
 
@@ -365,6 +452,10 @@ template lean*(self: Unit, degrees: float) =
   wait self.lean(degrees, move_mode)
 
 template move*[T: Unit](new_enu_target: T) =
+  ## Switch to move mode: commands like `forward` and `turn` now move
+  ## the unit around instead of drawing blocks. `move me` moves this
+  ## unit; `move enemy` steers a different one. (If the speed was 0,
+  ## it's bumped to 1 so you can actually see something happen.)
   when enu_target is Build:
     enu_target.end_asap()
   enu_target = new_enu_target
@@ -373,6 +464,10 @@ template move*[T: Unit](new_enu_target: T) =
     enu_target.speed = 1
 
 template build*(new_enu_target: Unit) =
+  ## Switch to build mode: commands like `forward` and `turn` steer
+  ## the drawing turtle, leaving a trail of blocks. This is the normal
+  ## mode for a Build, so you mostly need it to switch back after
+  ## `move`, or to aim commands at a different unit: `build enemy`.
   when enu_target is Build:
     enu_target.end_asap()
   enu_target = new_enu_target
@@ -442,14 +537,16 @@ template t*(enu_target: NegativeNode) =
   turn(enu_target)
 
 proc distance*(position: Vector3): float =
+  ## How far away something is from this unit, in blocks.
+  ## `player.distance` or `distance vec3(10, 0, 10)`.
   position.distance_to(active_unit().position)
 
 proc distance*(node: Unit): float =
   node.position.distance
 
 proc find_by_id*(id: string): Unit =
-  ## Recursively search every unit in the world for one with this id.
-  ## Returns nil if not found.
+  ## Search every unit in the world for the one with this id. Returns
+  ## `nil` if there's no such unit.
   for u in all_units():
     if u.id == id:
       return u
@@ -478,9 +575,13 @@ proc units_near*(x, y, z: float, radius = 30.0): string =
   lines.join("\n")
 
 proc near*(node: Unit | Vector3, less_than = 5.0): bool =
+  ## `true` if something is closer than `less_than` blocks (5 unless
+  ## you say otherwise). `if player.near:` or `if player.near(20):`.
   result = node.distance < less_than
 
 proc far*(node: Unit | Vector3, greater_than = 100.0): bool =
+  ## `true` if something is farther than `greater_than` blocks
+  ## (100 unless you say otherwise).
   result = node.distance > greater_than
 
 proc over*(node: Unit): bool =
@@ -490,12 +591,17 @@ proc under*(node: Unit): bool =
   result = active_unit().position.z < node.position.z
 
 proc height*(self: Vector3): float =
+  ## How high up something is. The same as `position.y`.
   self.y
 
 proc height*(self: Unit): float =
   self.position.y
 
 template go_home*() =
+  ## Head back to the start position by going forward, left, and down
+  ## the right amounts. Something solid can block the trip, so if it
+  ## really matters, compare `position` to `start_position` afterward
+  ## to check you made it.
   enu_target.go_home
 
 import macros, tables
@@ -511,6 +617,9 @@ proc rng(): var Rand =
   unit.rng
 
 proc rand*[T: int | float](range: Slice[T]): T =
+  ## A random number from a range: `rand(1..6)` rolls a die. Mostly
+  ## you don't even need to call this — passing a range where a number
+  ## goes does it automatically, like `forward 2..10`.
   rnd.rand rng(),
     if range.a > range.b:
       range.b .. range.a
@@ -530,6 +639,9 @@ converter float_slice_to_float*(range: Slice[float]): float =
   rand(range)
 
 proc fuzzed*(self, range: float): float =
+  ## A copy of a number or position, nudged by a random amount up to
+  ## `range`. `position.fuzzed(0.5)` is great for jitters, shivers and
+  ## nervous-looking bots.
   result =
     if range > 0:
       self + (rand(0.0 .. range) - (range / 2.0))
@@ -546,6 +658,10 @@ proc fuzzed*(self: Vector3, x, y, z: float): Vector3 =
   self.fuzzed(vec3(x, y, z))
 
 template times*(count: int, body: untyped): untyped =
+  ## Do something over and over. `4.times: forward 5; turn right`
+  ## draws a square. Inside the block, `first` and `last` tell you if
+  ## this is the first or last time through. Want a counter? Ask for
+  ## one: `8.times(side):` counts `side` up from 0 to 7.
   for x in 0 ..< count:
     let first {.inject.} = (x == 0)
     let last {.inject.} = (x == count - 1)
@@ -558,15 +674,21 @@ template times*(count: int, name: untyped, body: untyped): untyped =
     body
 
 template x*(count: int, body: untyped): untyped =
+  ## Shorthand for `times`. `5.x: forward 2`.
   times(count, body)
 
 macro dump*(x: typed): untyped =
+  ## Print an expression and its value. `dump score` prints
+  ## `score = 10`. Saves you typing the name twice while debugging.
   let s = x.toStrLit
   let r = quote:
     echo(`s` & " = " & $`x`)
   return r
 
 template cycle*[T](args: varargs[T]): T =
+  ## Each time it's called, hand back the next value in the list,
+  ## looping around forever: red, green, blue, red, green, blue...
+  ## `color = cycle(red, green, blue)`.
   var
     positions {.global.}: Table[(string, int, int), int]
     key = instantiation_info()
@@ -579,22 +701,32 @@ template cycle*[T](args: varargs[T]): T =
   args[positions[key]]
 
 proc random*[T](args: varargs[T]): T =
+  ## Pick one of the choices at random.
+  ## `color = random(red, green, blue)`.
   let i = rnd.rand(rng(), 0 .. (args.len - 1))
   args[i]
 
 proc contains*(max, chance: int): bool =
+  ## Roll the dice: `1 in 10` is true 1 time out of 10. Use it for
+  ## things that should only happen sometimes:
+  ## `if 1 in 100: echo "jackpot!"`.
   var r = rnd.rand(rng(), 1 .. max)
   result = r <= chance
 
 template forever*(body) =
+  ## Do something forever. The same as `while true`, but friendlier.
+  ## `o` is the short version (it looks like a loop, see?).
   while true:
     body
 
 template o*(body) =
+  ## Shorthand for `forever`.
   while true:
     body
 
 proc `+`*(self: PositionOffset, offset: float): PositionOffset =
+  ## Add or subtract extra distance from a spot like `home`.
+  ## `forward home + 2` stops 2 blocks past home.
   result = self
   result.offset += offset
 
@@ -603,6 +735,8 @@ proc `-`*(self: PositionOffset, offset: float): PositionOffset =
   result.offset -= offset
 
 proc go*(unit: Unit) =
+  ## Travel to another unit: turn to face it, head forward until you
+  ## arrive, then drop down to its height.
   # save position and height in case unit moves
   var position = unit.position
   var height = unit.height
@@ -611,12 +745,17 @@ proc go*(unit: Unit) =
   active_unit().down(active_unit().height - height, 2)
 
 proc even*(self: int): bool =
+  ## `true` for even numbers. `if frame.even:` does something every
+  ## other time.
   self mod 2 == 0
 
 proc odd*(self: int): bool =
+  ## `true` for odd numbers.
   not self.even
 
 template `\`*(s: string): string =
+  ## Put values inside text: `\"score: {score}"` becomes
+  ## `"score: 10"`. Anything in curly braces gets filled in.
   var f = fmt(s)
   f.remove_prefix("\n")
   f.remove_suffix(' ')
@@ -628,6 +767,9 @@ proc init*[T](_: type Query, results: open_array[T]): Query[seq[T]] =
   result.truthy = results.len > 0
 
 template `?`*[T: ref](self: T): Query[T] =
+  ## "Is this something?" `?player.open_sign` is `true` if the player
+  ## has a sign open, `false` if there's nothing there. Works on most
+  ## things: empty text, empty lists and zero all count as "nothing".
   Query[T](truthy: not self.is_nil)
 
 template `?`*[T: object](self: T): Query[T] =
@@ -661,6 +803,8 @@ converter to_bool*(src: Query): bool =
   src.truthy
 
 proc `or`*[T: not bool](a, b: T): T =
+  ## Pick the first value that's "something". `name or "mystery guest"`
+  ## gives you `name`, unless it's empty.
   if ?a:
     result = a
   else:
@@ -671,9 +815,13 @@ proc first_key*[K, V](self: Table[K, V]): K =
     return key
 
 template reset*(clear = false) =
+  ## Send the unit back to its start position, rotation and scale.
+  ## With `clear = true`, a Build also forgets its drawn blocks.
   enu_target.reset(clear)
 
 proc loop_finished*() =
+  ## Called by Enu at the end of each trip through a command loop.
+  ## You won't need this in a script.
   let unit = active_unit()
   if ?unit.query_results:
     let key = unit.query_results.first_key
@@ -702,6 +850,9 @@ iterator items*[T](self: Query[seq[T]]): T =
     yield item
 
 proc all*(_: type Bot): Query[seq[Bot]] =
+  ## Every unit of a kind in the world: `Bot.all`, `Build.all`,
+  ## `Player.all`, `Sign.all` or `Unit.all`. Loop over them with
+  ## `for bot in Bot.all:`.
   Query.init all_bots()
 
 proc all*(T: type Build): Query[seq[Build]] =
@@ -723,17 +874,24 @@ proc `[]`*[T: Unit](self: Query[seq[T]], index: int): T =
   self.result[index]
 
 proc first*[T: Unit](_: type T): T =
+  ## The first unit of a kind: `Player.first` is the first player,
+  ## `Bot.first` the first bot. `nil` if there aren't any.
   for player in T.all.result:
     return player
 
 proc added*(_: type Player): Query[seq[Player]] =
+  ## Players who joined since the last time you asked. Useful in a
+  ## loop to greet newcomers.
   Query.init added_units().filter_it(it of Player).map_it(Player(it))
 
 proc hit*(_: type Player): Query[seq[Player]] =
+  ## The players currently touching this unit, if any.
+  ## `if Player.hit as toucher:` grabs one to work with.
   let rr = active_unit().current_colliders("Player").map_it(Player(it))
   result = Query.init rr
 
 proc hit*(unit: Unit): bool =
+  ## `true` if this unit is touching another unit. `if player.hit:`.
   active_unit().hit(unit)
 
 proc `in`*(unit: Unit): bool =
@@ -743,6 +901,9 @@ proc register_type[T: Unit](unit: T) =
   register_template_node(unit, $T)
 
 template `as`*[T](q: Query[seq[T]], name: untyped): bool =
+  ## Grab a result from a query and give it a name, right inside an
+  ## `if`: `if Player.hit as toucher: toucher.bounce`. Only works
+  ## inside a command loop.
   if loop_context.is_nil:
     raise
       ObjectConversionDefect.init("`as` can only be used inside an action loop")

--- a/share/vmlib/enu/players.nim
+++ b/share/vmlib/enu/players.nim
@@ -1,30 +1,53 @@
-import types, base_api, vm_bridge_utils, builds_private
+import core, vm_bridge_utils, builds_private
 
 bridged_to_host:
   proc tool*(self: Player): Tools
+    ## The tool the player is holding right now, like `CodeMode` or
+    ## `BlueBlock`. Assign to switch tools for them.
+
   proc `tool=`*(self: Player, value: Tools)
   proc tools_has*(self: Player, tool: Tools): bool
   proc tools_incl*(self: Player, tool: Tools)
   proc tools_excl*(self: Player, tool: Tools)
   proc tools_clear*(self: Player)
   proc playing*(self: Player): bool
+    ## `true` in play mode, `false` in edit mode. Assign to switch.
+
   proc `playing=`*(self: Player, value: bool)
   proc flying*(self: Player): bool
+    ## Whether the player is flying. `player.flying = true` — no
+    ## double-jump needed.
+
   proc `flying=`*(self: Player, value: bool)
   proc running*(self: Player): bool
+    ## Whether the player is running.
+
   proc `running=`*(self: Player, value: bool)
   proc god*(self: Player): bool
+    ## God mode: hidden things show up, and locked things can be
+    ## edited. With great power, etc.
+
   proc `god=`*(self: Player, value: bool)
   proc coding*(self: Player): Unit
+    ## The unit whose code the player has open, or `nil` if the editor
+    ## is closed. Assign a unit to open its code for them.
+
   proc `coding=`*(self: Player, value: Unit)
   proc open_sign*(self: Player): Sign
+    ## The sign the player is reading, or `nil` if none. Assign a sign
+    ## to shove it in front of them.
+
   proc `open_sign=`*(self: Player, value: Sign)
   proc executing_player*(): Player
+    ## The player who ran this script. `runner` is the friendly name.
+
   proc block_log*(self: Unit): string
   proc clear_block_log*(self: Unit)
 
 var player*: Player
 template runner*(): Player =
+  ## The player who ran this script — useful in multiplayer, where
+  ## `player` is just the first one.
   executing_player()
 
 register_state_init(
@@ -33,6 +56,7 @@ register_state_init(
 )
 
 proc number*(self: Player): int =
+  ## Which player this is: player 1, player 2, and so on.
   for i, player in all_players():
     if player == self:
       return i + 1
@@ -44,18 +68,26 @@ type ToolSet* = distinct Player
   ## host one tool at a time, so no real set crosses the bridge.
 
 proc tools*(self: Player): ToolSet =
+  ## The tools in the player's toolbar. Check with `in`, add with
+  ## `incl`, remove with `excl`, or assign a whole set:
+  ## `player.tools = {CodeMode, BlueBlock}`.
   ToolSet(self)
 
 proc contains*(tools: ToolSet, tool: Tools): bool =
+  ## `true` if the tool is in the toolbar:
+  ## `if PlaceBot in player.tools:`.
   Player(tools).tools_has(tool)
 
 proc incl*(tools: ToolSet, tool: Tools) =
+  ## Add a tool to the toolbar.
   Player(tools).tools_incl(tool)
 
 proc excl*(tools: ToolSet, tool: Tools) =
+  ## Take a tool out of the toolbar.
   Player(tools).tools_excl(tool)
 
 proc clear*(tools: ToolSet) =
+  ## Empty the toolbar completely.
   Player(tools).tools_clear()
 
 iterator items*(tools: ToolSet): Tools =
@@ -76,8 +108,8 @@ proc `$`*(tools: ToolSet): string =
   result &= "}"
 
 proc `tools=`*(self: Player, value: set[Tools]) =
-  ## Replace the available tools with `value` (a normal VM set literal, iterated
-  ## here — never marshalled). `None` is ignored; it isn't a selectable tool.
+  ## Replace the whole toolbar at once:
+  ## `player.tools = {CodeMode, BlueBlock, PlaceBot}`.
   self.tools_clear()
   for tool in value:
     if tool != None:

--- a/share/vmlib/enu/players.nim
+++ b/share/vmlib/enu/players.nim
@@ -1,3 +1,6 @@
+## Commands for the people playing: their tools, whether they're flying
+## or playing, and what they have open.
+
 import core, vm_bridge_utils, builds_private
 
 bridged_to_host:

--- a/share/vmlib/enu/signs.nim
+++ b/share/vmlib/enu/signs.nim
@@ -1,21 +1,39 @@
 import system except echo
 import std/[strutils, math, wrapnils, options]
-import types, base_api, vm_bridge_utils, base_bridge_private
+import core, vm_bridge_utils, base_bridge_private
 
 bridged_to_host:
   proc message*(self: Sign): string
+    ## The text on the sign. It's markdown, so `**bold**`, lists and
+    ## headings all work.
+
   proc `message=`*(self: Sign, value: string)
   proc more*(self: Sign): string
+    ## Extra text shown when the player opens the sign — good for
+    ## the long version of the story.
+
   proc `more=`*(self: Sign, value: string)
   proc width*(self: Sign): float
+    ## How wide the sign is, in blocks.
+
   proc `width=`*(self: Sign, value: float)
   proc height*(self: Sign): float
+    ## How tall the sign is, in blocks.
+
   proc `height=`*(self: Sign, value: float)
   proc size*(self: Sign): int
+    ## The text size. Bigger numbers, bigger letters.
+
   proc `size=`*(self: Sign, value: int)
   proc open*(self: Sign): bool
+    ## Whether the sign is open full-screen for reading. Set it to pop
+    ## the sign open (or slam it shut).
+
   proc `open=`*(self: Sign, value: bool)
   proc billboard*(self: Sign): bool
+    ## Whether the sign spins to always face the player, like it's
+    ## watching you. (Politely.)
+
   proc `billboard=`*(self: Sign, value: bool)
 
 proc say*(
@@ -27,6 +45,11 @@ proc say*(
     size = int.high,
     billboard = none(bool),
 ): Sign {.discardable.} =
+  ## Show a message on a sign above the unit: `say "Hello!"`. Call it
+  ## again to change the message, or `say ""` to put the sign away.
+  ## Markdown works, `more` adds extra text for when the sign is
+  ## opened, and `width`/`height`/`size` control the shape if you're
+  ## picky.
   let defaults: tuple[width: float, height: float, size: int, billboard: bool] =
     if ?self.sign:
       (self.sign.width, self.sign.height, self.sign.size, self.sign.billboard)

--- a/share/vmlib/enu/signs.nim
+++ b/share/vmlib/enu/signs.nim
@@ -1,3 +1,5 @@
+## Signs and speech: `say` something, and control how the sign looks.
+
 import system except echo
 import std/[strutils, math, wrapnils, options]
 import core, vm_bridge_utils, base_bridge_private

--- a/share/vmlib/enu/state_machine.nim
+++ b/share/vmlib/enu/state_machine.nim
@@ -1,5 +1,5 @@
 import std/[macros, strformat, strutils, sequtils, tables]
-import types, macro_helpers, base_api
+import core, macro_helpers
 
 proc current_loop(value: Loop = nil): Loop =
   var loop {.global.}: Loop
@@ -107,6 +107,14 @@ template loop_body(body: untyped) =
       looping = ctx.advance(frame)
 
 macro loop*(body: untyped) =
+  ## A command loop — the heart of a unit's behavior. The body runs
+  ## over and over (about twice a second), switching between states
+  ## with `->` rules:
+  ##
+  ##   loop:
+  ##     nil -> wander
+  ##     if player.near:
+  ##       wander -> hide
   discard current_loop(Loop())
   result = new_stmt_list()
   let body =
@@ -242,9 +250,16 @@ proc transition(from_state, to_state, body, immediate: NimNode): NimNode =
         raise (ref Halt)()
 
 macro `==>`*(from_state: untyped, to_state: untyped, body: untyped = nil) =
+  ## Like `->`, but impatient: switches states right away instead of
+  ## waiting for the current state to finish what it's doing.
   result = transition(from_state, to_state, body, ident"true")
 
 macro `->`*(from_state: untyped, to_state: untyped, body: untyped = nil) =
+  ## A state change rule for `loop`. `wander -> hide` means "if we're
+  ## wandering, start hiding". `nil` is the state you begin in, `any`
+  ## matches every state, `others` matches every state except the one
+  ## you're switching to, and `(a, b) -> c` matches either. Add a
+  ## `do:` block to run something once at the moment of the switch.
   result = transition(from_state, to_state, body, ident"false")
 
 when is_main_module:

--- a/share/vmlib/enu/state_machine.nim
+++ b/share/vmlib/enu/state_machine.nim
@@ -1,3 +1,6 @@
+## Command loops and states: `loop`, and the `->` and `==>` rules that
+## switch between behaviors.
+
 import std/[macros, strformat, strutils, sequtils, tables]
 import core, macro_helpers
 

--- a/share/vmlib/enu/testing.nim
+++ b/share/vmlib/enu/testing.nim
@@ -1,5 +1,5 @@
-## Simple testing framework for Enu VM tests
-## Follows unittest API but works in NimScript/VM mode
+## A little testing framework, for checking that your creations do what
+## you think they do: `suite`, `test` and `check`.
 
 import std/strutils
 import base_bridge

--- a/share/vmlib/enu/testing.nim
+++ b/share/vmlib/enu/testing.nim
@@ -14,11 +14,13 @@ var
   failure_msg: string
 
 template suite*(name: string, body: untyped) =
+  ## A group of related tests: `suite "gravity": ...`.
   current_suite = name
   echo "Suite: ", name
   body
 
 template test*(name: string, body: untyped) =
+  ## One test with a name. Put `check`s inside.
   inc total_tests
   test_failed = false
   failure_msg = ""
@@ -32,19 +34,24 @@ template test*(name: string, body: untyped) =
     echo "  [OK] ", name
 
 template check*(cond: untyped) =
+  ## Check that something is true. If it isn't, the test fails and
+  ## tells you what went wrong.
   if not test_failed:
     if not cond:
       test_failed = true
       failure_msg = ast_to_str(cond) & " was false"
 
 template require*(cond: untyped) =
+  ## The same as `check`.
   check(cond)
 
 proc test_summary*() =
+  ## Print how many tests passed and failed. Call it at the end.
   echo ""
   echo "=== Summary ==="
   echo total_tests, " tests run: ", passed_tests, " passed, ", failed_tests, " failed"
   signal_test_complete(failed_tests)
 
 proc tests_failed*(): bool =
+  ## `true` if any test has failed so far.
   failed_tests > 0

--- a/share/vmlib/enu/types.nim
+++ b/share/vmlib/enu/types.nim
@@ -1,17 +1,25 @@
-import std/[strutils, strformat, macros, math, hashes, tables, random]
+import std/[tables, random, macros]
 
 var global_default* = false
 
 const yes* = true
 const no* = false
-const ASAP* = 0.0  ## Magic value for speed to enable ASAP mode
+const ASAP* = 0.0
+  ## Magic speed value. `speed = ASAP` makes a build draw everything at
+  ## once instead of block by block.
 
 type
   Vector3* = tuple[x, y, z: float]
+    ## A spot (or a direction) in the world. `x` is left/right, `y` is
+    ## up/down, and `z` is forward/back.
 
   WorldBox* = tuple[min, max: Vector3]
+    ## An invisible box around a unit, described by its lowest corner
+    ## and its highest corner. Used to check what fits where.
 
   Directions* = enum
+    ## The 6 directions a unit can move, turn or lean. Each one has a
+    ## single-letter shorthand, so `turn r` means `turn right`.
     up
     u
     down
@@ -26,6 +34,8 @@ type
     b
 
   Unit* = ref object of RootObj
+    ## Anything that exists in the world — a build, a bot, a sign, or
+    ## the player. Most commands work on any unit.
     id: int
     name*: string
     advance_state_machine*: proc(): bool
@@ -35,25 +45,41 @@ type
     query_results*: Table[string, seq[Unit]]
 
   Query*[T] = object of RootObj
+    ## The answer to a question like `Bot.all` or `?player`. Acts like
+    ## `true` or `false` in an `if`, and may carry results you can loop
+    ## over.
     result*: T
     truthy*: bool
 
   World* = ref object of RootObj
+    ## The world itself. There's exactly one, named `world`. Change its
+    ## settings to change the scenery.
 
   PositionOffset* = object
+    ## A position plus a distance, like `home + 5`. Move commands
+    ## accept these as targets.
     position*: Vector3
     offset*: float
     direction*: Vector3
 
   Bot* = ref object of Unit
+    ## A robot character. Bots can walk, run, play animations, and be
+    ## programmed to do whatever you like.
 
   Build* = ref object of Unit
+    ## Something made of blocks. Builds have a drawing turtle that
+    ## commands like `forward` and `turn` steer around.
 
   Sign* = ref object of Unit
+    ## A sign or message floating in the world.
 
   Player* = ref object of Unit
+    ## A person playing the game. The one at this computer is named
+    ## `player`.
 
   Colors* = enum
+    ## The colors blocks come in. `eraser` isn't really a color — it
+    ## removes blocks instead of drawing them.
     eraser
     blue
     red
@@ -76,6 +102,8 @@ type
     from_states*: seq[(string, NimNode)]
 
   Tools* = enum
+    ## Everything that can go in a player's toolbar: the code editor,
+    ## one tool for each block color, and the bot placer.
     CodeMode
     BlueBlock
     RedBlock
@@ -86,290 +114,26 @@ type
     PlaceBot
     None
 
-proc vec3*(x, y, z: float): Vector3 {.inline.} =
-  (x: x, y: y, z: z)
-
-const
-  UP* = vec3(0, 1, 0)
-  DOWN* = vec3(0, -1, 0)
-  BACK* = vec3(0, 0, 1)
-  FORWARD* = vec3(0, 0, -1)
-  RIGHT* = vec3(1, 0, 0)
-  LEFT* = vec3(-1, 0, 0)
-  UNSET_POSITION* = vec3(float.high, float.high, float.high)
-
-# math from https://github.com/pragmagic/godot-nim/blob/7fb22f69af92aa916e56dba14ba3938fc7fa1dd1/godot/core/godotbase.nim
-
-const EPSILON = 0.00001'f32
-
-proc isEqualApprox*(a, b: float32): bool {.inline, noinit.} =
-  abs(a - b) < EPSILON
-
-proc isEqualApprox*(a, b: float64): bool {.inline, noinit.} =
-  abs(a - b) < EPSILON
-
-proc sign*(a: float32): float32 {.inline, noinit.} =
-  if a < 0: -1.0'f32 else: 1.0'f32
-
-proc sign*(a: float64): float64 {.inline, noinit.} =
-  if a < 0: -1.0'f64 else: 1.0'f64
-
-proc stepify*(value, step: float64): float64 {.inline, noinit.} =
-  if step != 0'f64:
-    floor(value / step + 0.5'f64) * step
-  else:
-    value
-
-proc stepify*(value, step: float32): float32 {.inline, noinit.} =
-  if step != 0'f32:
-    floor(value / step + 0.5'f32) * step
-  else:
-    value
-
-# Vector3 math. https://github.com/pragmagic/godot-nim/blob/7fb22f69af92aa916e56dba14ba3938fc7fa1dd1/godot/core/vector3.nim
-
-proc `+`*(a, b: Vector3): Vector3 {.inline.} =
-  result.x = a.x + b.x
-  result.y = a.y + b.y
-  result.z = a.z + b.z
-
-proc `+=`*(a: var Vector3, b: Vector3) {.inline.} =
-  a.x += b.x
-  a.y += b.y
-  a.z += b.z
-
-proc `-`*(a, b: Vector3): Vector3 {.inline.} =
-  result.x = a.x - b.x
-  result.y = a.y - b.y
-  result.z = a.z - b.z
-
-proc `-=`*(a: var Vector3, b: Vector3) {.inline.} =
-  a.x -= b.x
-  a.y -= b.y
-  a.z -= b.z
-
-proc `*`*(a, b: Vector3): Vector3 {.inline.} =
-  result.x = a.x * b.x
-  result.y = a.y * b.y
-  result.z = a.z * b.z
-
-proc `*=`*(a: var Vector3, b: Vector3) {.inline.} =
-  a.x *= b.x
-  a.y *= b.y
-  a.z *= b.z
-
-proc `*`*(a: Vector3, b: float32): Vector3 {.inline.} =
-  result.x = a.x * b
-  result.y = a.y * b
-  result.z = a.z * b
-
-proc `*`*(b: float32, a: Vector3): Vector3 {.inline.} =
-  a * b
-
-proc `*=`*(a: var Vector3, b: float32) {.inline.} =
-  a.x *= b
-  a.y *= b
-  a.z *= b
-
-proc `/`*(a, b: Vector3): Vector3 =
-  result.x = a.x / b.x
-  result.y = a.y / b.y
-  result.z = a.z / b.z
-
-proc `/=`*(a: var Vector3, b: Vector3) {.inline.} =
-  a.x /= b.x
-  a.y /= b.y
-  a.z /= b.z
-
-proc `/`*(a: Vector3, b: float32): Vector3 =
-  result.x = a.x / b
-  result.y = a.y / b
-  result.z = a.z / b
-
-proc `/=`*(a: var Vector3, b: float32) {.inline.} =
-  a.x /= b
-  a.y /= b
-  a.z /= b
-
-proc `==`*(a, b: Vector3): bool {.inline.} =
-  a.x == b.x and a.y == b.y and a.z == b.z
-
-proc `<`*(a, b: Vector3): bool =
-  if a.x == b.x:
-    if a.y == b.y:
-      return a.z < b.z
-    return a.y < b.y
-  return a.x < b.x
-
-proc `-`*(self: Vector3): Vector3 =
-  result.x = -self.x
-  result.y = -self.y
-  result.z = -self.z
-
-proc minAxis*(self: Vector3): int {.inline.} =
-  if self.x < self.y:
-    if self.x < self.z: 0 else: 2
-  else:
-    if self.y < self.z: 1 else: 2
-
-proc maxAxis*(self: Vector3): int {.inline.} =
-  if self.x < self.y:
-    if self.y < self.z: 2 else: 1
-  else:
-    if self.x < self.z: 2 else: 0
-
-proc length*(self: Vector3): float32 {.inline.} =
-  let x2 = self.x * self.x
-  let y2 = self.y * self.y
-  let z2 = self.z * self.z
-
-  result = sqrt(x2 + y2 + z2)
-
-proc lengthSquared*(self: Vector3): float32 {.inline.} =
-  let x2 = self.x * self.x
-  let y2 = self.y * self.y
-  let z2 = self.z * self.z
-
-  result = x2 + y2 + z2
-
-proc normalize*(self: var Vector3) {.inline.} =
-  let len = self.length()
-  if len == 0:
-    self.x = 0
-    self.y = 0
-    self.z = 0
-  else:
-    self.x /= len
-    self.y /= len
-    self.z /= len
-
-proc normalized*(self: Vector3): Vector3 {.inline.} =
-  result = self
-  result.normalize()
-
-proc isNormalized*(self: Vector3): bool {.inline.} =
-  self.lengthSquared().isEqualApprox(1.0'f32)
-
-proc zero*(self: var Vector3) {.inline.} =
-  self.x = 0
-  self.y = 0
-  self.z = 0
-
-proc inverse*(self: Vector3): Vector3 {.inline.} =
-  vec3(1.0'f32 / self.x, 1.0'f32 / self.y, 1.0'f32 / self.z)
-
-proc cross*(self, other: Vector3): Vector3 {.inline.} =
-  vec3(
-    self.y * other.z - self.z * other.y,
-    self.z * other.x - self.x * other.z,
-    self.x * other.y - self.y * other.x,
-  )
-
-proc dot*(self, other: Vector3): float32 {.inline.} =
-  self.x * other.x + self.y * other.y + self.z * other.z
-
-proc abs*(self: Vector3): Vector3 {.inline.} =
-  vec3(abs(self.x), abs(self.y), abs(self.z))
-
-proc sign*(self: Vector3): Vector3 {.inline.} =
-  vec3(sign(self.x), sign(self.y), sign(self.z))
-
-proc floor*(self: Vector3): Vector3 {.inline.} =
-  vec3(floor(self.x), floor(self.y), floor(self.z))
-
-proc ceil*(self: Vector3): Vector3 {.inline.} =
-  vec3(ceil(self.x), ceil(self.y), ceil(self.z))
-
-proc lerp*(self: Vector3, other: Vector3, t: float32): Vector3 {.inline.} =
-  vec3(
-    self.x + t * (other.x - self.x),
-    self.y + t * (other.y - self.y),
-    self.z + t * (other.z - self.z),
-  )
-
-proc distanceTo*(self, other: Vector3): float32 {.inline.} =
-  (other - self).length()
-
-proc distanceSquaredTo*(self, other: Vector3): float32 {.inline.} =
-  (other - self).lengthSquared()
-
-proc angleTo*(self, other: Vector3): float32 {.inline.} =
-  arctan2(self.cross(other).length(), self.dot(other))
-
-proc slide*(self, n: Vector3): Vector3 {.inline.} =
-  assert(n.isNormalized())
-  result = self - n * self.dot(n)
-
-proc reflect*(self, n: Vector3): Vector3 {.inline.} =
-  assert(n.isNormalized())
-  result = 2.0'f32 * n * self.dot(n) - self
-
-proc bounce*(self, n: Vector3): Vector3 {.inline.} =
-  -self.reflect(n)
-
-proc snap*(self: var Vector3, other: Vector3) =
-  self.x = stepify(self.x, other.x)
-  self.y = stepify(self.y, other.y)
-  self.z = stepify(self.z, other.z)
-
-proc snapped*(self: Vector3, other: Vector3): Vector3 =
-  result = self
-  result.snap(other)
-
-proc cubicInterpolate*(self, b, preA, postB: Vector3, t: float32): Vector3 =
-  let p0 = preA
-  let p1 = self
-  let p2 = b
-  let p3 = postB
-
-  let t2 = t * t
-  let t3 = t2 * t
-
-  result =
-    0.5 * (
-      (p1 * 2.0) + (-p0 + p2) * t + (2.0 * p0 - 5.0 * p1 + 4 * p2 - p3) * t2 +
-      (-p0 + 3.0 * p1 - 3.0 * p2 + p3) * t3
-    )
-
-proc moveToward*(vFrom, to: Vector3, delta: float32): Vector3 =
-  let
-    vd = to - vFrom
-    vLen = vd.length
-
-  if vLen <= delta or vLen < EPSILON:
-    result = to
-  else:
-    result = vFrom + (vd / vLen) * delta
-
-# public api
-
-converter vec3_to_bool*(v: Vector3): bool =
-  v != vec3(0, 0, 0)
-
-proc init*[T: Exception](
-    kind: type[T], message: string, parent: ref Exception = nil
-): ref Exception =
-  (ref kind)(msg: message, parent: parent)
-
 # Timing types - simple wrappers that don't require posix
 
 type
   Timestamp* = object
-    ## A point in time, represented as seconds since program start.
+    ## A point in time, measured in seconds since Enu started. Get one
+    ## with `now()`.
     seconds_since_start: float
 
   Duration* = object
-    ## A duration of time.
+    ## An amount of time. Subtracting two timestamps gives you one.
     total_seconds: float
 
-proc init_timestamp*(seconds: float): Timestamp =
+proc init*(_: type Timestamp, seconds: float): Timestamp =
   Timestamp(seconds_since_start: seconds)
 
-proc init_duration*(seconds: float): Duration =
+proc init*(_: type Duration, seconds: float): Duration =
   Duration(total_seconds: seconds)
 
 proc `-`*(a, b: Timestamp): Duration =
-  ## Calculate duration between two timestamps.
+  ## Subtract timestamps to find out how much time passed between them.
   Duration(total_seconds: a.seconds_since_start - b.seconds_since_start)
 
 proc `+`*(a: Timestamp, b: Duration): Timestamp =
@@ -385,11 +149,11 @@ proc `-`*(a, b: Duration): Duration =
   Duration(total_seconds: a.total_seconds - b.total_seconds)
 
 proc seconds*(d: Duration): float =
-  ## Get duration in seconds.
+  ## The duration as a number of seconds.
   d.total_seconds
 
 proc milliseconds*(d: Duration): float =
-  ## Get duration in milliseconds.
+  ## The duration as a number of milliseconds.
   d.total_seconds * 1000.0
 
 proc `$`*(d: Duration): string =
@@ -424,26 +188,3 @@ proc `<`*(a, b: Timestamp): bool =
 
 proc `>`*(a, b: Timestamp): bool =
   a.seconds_since_start > b.seconds_since_start
-
-# WorldBox helpers — axis-aligned world-space bounding box queries.
-# Returned by `bounds()` and consumed by `box_is_free`, `units_overlapping`,
-# `overlaps`, etc. See `docs/notes/instance-query-api.md`.
-
-proc size*(b: WorldBox): Vector3 {.inline.} =
-  b.max - b.min
-
-proc centre*(b: WorldBox): Vector3 {.inline.} =
-  (b.min + b.max) * 0.5
-
-proc contains*(b: WorldBox, p: Vector3): bool {.inline.} =
-  p.x >= b.min.x and p.x <= b.max.x and p.y >= b.min.y and p.y <= b.max.y and
-    p.z >= b.min.z and p.z <= b.max.z
-
-proc intersects*(a, b: WorldBox): bool {.inline.} =
-  not (
-    a.max.x < b.min.x or a.min.x > b.max.x or a.max.y < b.min.y or
-    a.min.y > b.max.y or a.max.z < b.min.z or a.min.z > b.max.z
-  )
-
-proc expanded*(b: WorldBox, margin: float): WorldBox {.inline.} =
-  (b.min - vec3(margin, margin, margin), b.max + vec3(margin, margin, margin))

--- a/share/vmlib/enu/vectors.nim
+++ b/share/vmlib/enu/vectors.nim
@@ -1,3 +1,6 @@
+## Math for positions and directions: `Vector3` arithmetic, distances,
+## and the `WorldBox` helpers.
+
 import std/math
 import types
 

--- a/share/vmlib/enu/vectors.nim
+++ b/share/vmlib/enu/vectors.nim
@@ -1,0 +1,305 @@
+import std/math
+import types
+
+proc vec3*(x, y, z: float): Vector3 {.inline.} =
+  ## Make a `Vector3` — a spot (or a direction) in the world.
+  ## `x` is left/right, `y` is up/down, and `z` is forward/back.
+  (x: x, y: y, z: z)
+
+const
+  UP* = vec3(0, 1, 0)
+  DOWN* = vec3(0, -1, 0)
+  BACK* = vec3(0, 0, 1)
+  FORWARD* = vec3(0, 0, -1)
+  RIGHT* = vec3(1, 0, 0)
+  LEFT* = vec3(-1, 0, 0)
+  UNSET_POSITION* = vec3(float.high, float.high, float.high)
+
+# math from https://github.com/pragmagic/godot-nim/blob/7fb22f69af92aa916e56dba14ba3938fc7fa1dd1/godot/core/godotbase.nim
+
+const EPSILON = 0.00001'f32
+
+proc isEqualApprox*(a, b: float32): bool {.inline, noinit.} =
+  ## `true` if two numbers are so close that the difference doesn't matter.
+  abs(a - b) < EPSILON
+
+proc isEqualApprox*(a, b: float64): bool {.inline, noinit.} =
+  abs(a - b) < EPSILON
+
+proc sign*(a: float32): float32 {.inline, noinit.} =
+  ## `-1.0` for negative numbers, `1.0` for everything else.
+  if a < 0: -1.0'f32 else: 1.0'f32
+
+proc sign*(a: float64): float64 {.inline, noinit.} =
+  if a < 0: -1.0'f64 else: 1.0'f64
+
+proc stepify*(value, step: float64): float64 {.inline, noinit.} =
+  ## Snap `value` to the nearest multiple of `step`.
+  ## `stepify(7.3, 5.0)` is `5.0`. `stepify(8.0, 5.0)` is `10.0`.
+  if step != 0'f64:
+    floor(value / step + 0.5'f64) * step
+  else:
+    value
+
+proc stepify*(value, step: float32): float32 {.inline, noinit.} =
+  if step != 0'f32:
+    floor(value / step + 0.5'f32) * step
+  else:
+    value
+
+# Vector3 math. https://github.com/pragmagic/godot-nim/blob/7fb22f69af92aa916e56dba14ba3938fc7fa1dd1/godot/core/vector3.nim
+
+proc `+`*(a, b: Vector3): Vector3 {.inline.} =
+  result.x = a.x + b.x
+  result.y = a.y + b.y
+  result.z = a.z + b.z
+
+proc `+=`*(a: var Vector3, b: Vector3) {.inline.} =
+  a.x += b.x
+  a.y += b.y
+  a.z += b.z
+
+proc `-`*(a, b: Vector3): Vector3 {.inline.} =
+  result.x = a.x - b.x
+  result.y = a.y - b.y
+  result.z = a.z - b.z
+
+proc `-=`*(a: var Vector3, b: Vector3) {.inline.} =
+  a.x -= b.x
+  a.y -= b.y
+  a.z -= b.z
+
+proc `*`*(a, b: Vector3): Vector3 {.inline.} =
+  result.x = a.x * b.x
+  result.y = a.y * b.y
+  result.z = a.z * b.z
+
+proc `*=`*(a: var Vector3, b: Vector3) {.inline.} =
+  a.x *= b.x
+  a.y *= b.y
+  a.z *= b.z
+
+proc `*`*(a: Vector3, b: float32): Vector3 {.inline.} =
+  result.x = a.x * b
+  result.y = a.y * b
+  result.z = a.z * b
+
+proc `*`*(b: float32, a: Vector3): Vector3 {.inline.} =
+  a * b
+
+proc `*=`*(a: var Vector3, b: float32) {.inline.} =
+  a.x *= b
+  a.y *= b
+  a.z *= b
+
+proc `/`*(a, b: Vector3): Vector3 =
+  result.x = a.x / b.x
+  result.y = a.y / b.y
+  result.z = a.z / b.z
+
+proc `/=`*(a: var Vector3, b: Vector3) {.inline.} =
+  a.x /= b.x
+  a.y /= b.y
+  a.z /= b.z
+
+proc `/`*(a: Vector3, b: float32): Vector3 =
+  result.x = a.x / b
+  result.y = a.y / b
+  result.z = a.z / b
+
+proc `/=`*(a: var Vector3, b: float32) {.inline.} =
+  a.x /= b
+  a.y /= b
+  a.z /= b
+
+proc `==`*(a, b: Vector3): bool {.inline.} =
+  a.x == b.x and a.y == b.y and a.z == b.z
+
+proc `<`*(a, b: Vector3): bool =
+  if a.x == b.x:
+    if a.y == b.y:
+      return a.z < b.z
+    return a.y < b.y
+  return a.x < b.x
+
+proc `-`*(self: Vector3): Vector3 =
+  result.x = -self.x
+  result.y = -self.y
+  result.z = -self.z
+
+proc minAxis*(self: Vector3): int {.inline.} =
+  if self.x < self.y:
+    if self.x < self.z: 0 else: 2
+  else:
+    if self.y < self.z: 1 else: 2
+
+proc maxAxis*(self: Vector3): int {.inline.} =
+  if self.x < self.y:
+    if self.y < self.z: 2 else: 1
+  else:
+    if self.x < self.z: 2 else: 0
+
+proc length*(self: Vector3): float32 {.inline.} =
+  ## How long the vector is. If it's the difference between two
+  ## positions, this is the distance between them.
+  let x2 = self.x * self.x
+  let y2 = self.y * self.y
+  let z2 = self.z * self.z
+
+  result = sqrt(x2 + y2 + z2)
+
+proc lengthSquared*(self: Vector3): float32 {.inline.} =
+  let x2 = self.x * self.x
+  let y2 = self.y * self.y
+  let z2 = self.z * self.z
+
+  result = x2 + y2 + z2
+
+proc normalize*(self: var Vector3) {.inline.} =
+  ## Shrink or stretch the vector so its length is exactly 1, keeping
+  ## its direction. A vector like this is handy for pointing at things.
+  let len = self.length()
+  if len == 0:
+    self.x = 0
+    self.y = 0
+    self.z = 0
+  else:
+    self.x /= len
+    self.y /= len
+    self.z /= len
+
+proc normalized*(self: Vector3): Vector3 {.inline.} =
+  ## Like `normalize`, but returns a new vector instead of changing
+  ## this one.
+  result = self
+  result.normalize()
+
+proc isNormalized*(self: Vector3): bool {.inline.} =
+  self.lengthSquared().isEqualApprox(1.0'f32)
+
+proc zero*(self: var Vector3) {.inline.} =
+  self.x = 0
+  self.y = 0
+  self.z = 0
+
+proc inverse*(self: Vector3): Vector3 {.inline.} =
+  vec3(1.0'f32 / self.x, 1.0'f32 / self.y, 1.0'f32 / self.z)
+
+proc cross*(self, other: Vector3): Vector3 {.inline.} =
+  vec3(
+    self.y * other.z - self.z * other.y,
+    self.z * other.x - self.x * other.z,
+    self.x * other.y - self.y * other.x,
+  )
+
+proc dot*(self, other: Vector3): float32 {.inline.} =
+  self.x * other.x + self.y * other.y + self.z * other.z
+
+proc abs*(self: Vector3): Vector3 {.inline.} =
+  vec3(abs(self.x), abs(self.y), abs(self.z))
+
+proc sign*(self: Vector3): Vector3 {.inline.} =
+  vec3(sign(self.x), sign(self.y), sign(self.z))
+
+proc floor*(self: Vector3): Vector3 {.inline.} =
+  vec3(floor(self.x), floor(self.y), floor(self.z))
+
+proc ceil*(self: Vector3): Vector3 {.inline.} =
+  vec3(ceil(self.x), ceil(self.y), ceil(self.z))
+
+proc lerp*(self: Vector3, other: Vector3, t: float32): Vector3 {.inline.} =
+  ## Blend between two vectors. `t` is how far to go: `0.0` gives you
+  ## the first vector, `1.0` gives you the second, `0.5` is halfway.
+  vec3(
+    self.x + t * (other.x - self.x),
+    self.y + t * (other.y - self.y),
+    self.z + t * (other.z - self.z),
+  )
+
+proc distanceTo*(self, other: Vector3): float32 {.inline.} =
+  ## How far apart two positions are.
+  (other - self).length()
+
+proc distanceSquaredTo*(self, other: Vector3): float32 {.inline.} =
+  (other - self).lengthSquared()
+
+proc angleTo*(self, other: Vector3): float32 {.inline.} =
+  arctan2(self.cross(other).length(), self.dot(other))
+
+proc slide*(self, n: Vector3): Vector3 {.inline.} =
+  assert(n.isNormalized())
+  result = self - n * self.dot(n)
+
+proc reflect*(self, n: Vector3): Vector3 {.inline.} =
+  assert(n.isNormalized())
+  result = 2.0'f32 * n * self.dot(n) - self
+
+proc bounce*(self, n: Vector3): Vector3 {.inline.} =
+  -self.reflect(n)
+
+proc snap*(self: var Vector3, other: Vector3) =
+  self.x = stepify(self.x, other.x)
+  self.y = stepify(self.y, other.y)
+  self.z = stepify(self.z, other.z)
+
+proc snapped*(self: Vector3, other: Vector3): Vector3 =
+  result = self
+  result.snap(other)
+
+proc cubicInterpolate*(self, b, preA, postB: Vector3, t: float32): Vector3 =
+  let p0 = preA
+  let p1 = self
+  let p2 = b
+  let p3 = postB
+
+  let t2 = t * t
+  let t3 = t2 * t
+
+  result =
+    0.5 * (
+      (p1 * 2.0) + (-p0 + p2) * t + (2.0 * p0 - 5.0 * p1 + 4 * p2 - p3) * t2 +
+      (-p0 + 3.0 * p1 - 3.0 * p2 + p3) * t3
+    )
+
+proc moveToward*(vFrom, to: Vector3, delta: float32): Vector3 =
+  ## Take one step of size `delta` from one position toward another,
+  ## without overshooting.
+  let
+    vd = to - vFrom
+    vLen = vd.length
+
+  if vLen <= delta or vLen < EPSILON:
+    result = to
+  else:
+    result = vFrom + (vd / vLen) * delta
+
+converter vec3_to_bool*(v: Vector3): bool =
+  v != vec3(0, 0, 0)
+
+# WorldBox helpers — axis-aligned world-space bounding box queries.
+# Returned by `bounds()` and consumed by `box_is_free`, `units_overlapping`,
+# `overlaps`, etc. See `docs/notes/instance-query-api.md`.
+
+proc size*(b: WorldBox): Vector3 {.inline.} =
+  ## Width, height and depth of the box, as a `Vector3`.
+  b.max - b.min
+
+proc centre*(b: WorldBox): Vector3 {.inline.} =
+  ## The point in the middle of the box.
+  (b.min + b.max) * 0.5
+
+proc contains*(b: WorldBox, p: Vector3): bool {.inline.} =
+  ## `true` if the point is inside the box.
+  p.x >= b.min.x and p.x <= b.max.x and p.y >= b.min.y and p.y <= b.max.y and
+    p.z >= b.min.z and p.z <= b.max.z
+
+proc intersects*(a, b: WorldBox): bool {.inline.} =
+  ## `true` if two boxes overlap.
+  not (
+    a.max.x < b.min.x or a.min.x > b.max.x or a.max.y < b.min.y or
+    a.min.y > b.max.y or a.max.z < b.min.z or a.min.z > b.max.z
+  )
+
+proc expanded*(b: WorldBox, margin: float): WorldBox {.inline.} =
+  ## A copy of the box, grown by `margin` in every direction.
+  (b.min - vec3(margin, margin, margin), b.max + vec3(margin, margin, margin))

--- a/share/vmlib/enu/worlds.nim
+++ b/share/vmlib/enu/worlds.nim
@@ -5,6 +5,12 @@ var world* = World()
 
 bridged_to_host:
   proc environment*(self: World): string
+    ## The world's scenery and lighting, like `"default"` or `"space"`.
+    ## `world.environment = "space"` — instant outer space.
+
   proc `environment=`*(self: World, value: string)
   proc megapixels*(self: World): float
+    ## How sharp the screen looks. Lower numbers are blurrier but
+    ## faster — try turning this down if things get choppy.
+
   proc `megapixels=`*(self: World, value: float)

--- a/src/config.nims
+++ b/src/config.nims
@@ -77,7 +77,10 @@ else:
 
 switch("path", this_dir())
 switch("path", this_dir() & "/../generated")
-switch("path", this_dir() & "/../share/vmlib/enu")
+# The parent dir (not vmlib/enu itself), so vmlib modules don't shadow
+# src modules with the same name (core, types, ...). Import them with an
+# enu/ prefix, e.g. `import enu/shared/errors`.
+switch("path", this_dir() & "/../share/vmlib")
 
 when with_dir(this_dir(), system.file_exists("user_config.nims")):
   include "user_config.nims"

--- a/src/controllers/script_controllers/host_bridge.nim
+++ b/src/controllers/script_controllers/host_bridge.nim
@@ -11,7 +11,7 @@ import godotapi/[spatial, ray_cast]
 import
   core, models/[states, bots, builds, units, colors, signs, serializers, voxels]
 import libs/[interpreters, eval]
-import shared/errors
+import enu/shared/errors
 
 import ./[vars, scripting]
 include ./host_bridge_utils

--- a/src/models/bot_code_template.nim.nimf
+++ b/src/models/bot_code_template.nim.nimf
@@ -2,7 +2,7 @@
 #proc bot_code_template(file_name, imports: string): string =
 import system except echo, quit
 import std / [strutils]
-import types, class_macros, worlds, players, state_machine, base_api, bots,
+import core, class_macros, worlds, players, state_machine, bots,
   builds, signs, bots_private
 
 let instance_global_by_default = true

--- a/src/models/build_code_template.nim.nimf
+++ b/src/models/build_code_template.nim.nimf
@@ -2,7 +2,7 @@
 #proc build_code_template(file_name, imports: string): string =
 import system except echo, quit
 import std / [strutils]
-import types, class_macros, players, worlds, state_machine, base_api, bots,
+import core, class_macros, players, worlds, state_machine, bots,
   builds, signs, builds_private
 
 let instance_global_by_default = false

--- a/src/models/serializers.nim
+++ b/src/models/serializers.nim
@@ -580,11 +580,11 @@ proc run_state_initializers*(worker: Worker) =
   # register_state_init. Must run after every interpreter rebuild before any
   # unit script executes — unit scripts reference `player` at top level.
   let init_proc =
-    worker.interpreter.select_routine("initialize_state", "base_api")
+    worker.interpreter.select_routine("initialize_state", "core")
 
   assert not init_proc.is_nil,
-    "initialize_state routine not found in base_api module. " &
-      "Ensure base_api defines and exports initialize_state()."
+    "initialize_state routine not found in core module. " &
+      "Ensure core defines and exports initialize_state()."
 
   # Set player as active unit so VM hooks work correctly during initialization
   assert worker.active_unit.is_nil, "active_unit should be nil at this point"

--- a/tasks.nim
+++ b/tasks.nim
@@ -691,6 +691,7 @@ task dist, "Build distribution":
 
 proc generate_api_json() =
   # jsondoc JSON consumed by the API reference pages in docs/book/api
+  rm_dir "docs/book/api/json"
   let modules = [
     ("ed", "deps/ed/src/ed/types.nim"),
     ("ed/zens", "deps/ed/src/ed/zens/initializers.nim"),
@@ -698,8 +699,9 @@ proc generate_api_json() =
     ("ed/zens", "deps/ed/src/ed/zens/contexts.nim"),
     ("ed/zens", "deps/ed/src/ed/zens/validations.nim"),
     ("enu", "share/vmlib/enu/types.nim"),
+    ("enu", "share/vmlib/enu/vectors.nim"),
     ("enu", "share/vmlib/enu/base_bridge.nim"),
-    ("enu", "share/vmlib/enu/base_api.nim"),
+    ("enu", "share/vmlib/enu/core.nim"),
     ("enu", "share/vmlib/enu/builds.nim"),
     ("enu", "share/vmlib/enu/bots.nim"),
     ("enu", "share/vmlib/enu/players.nim"),

--- a/tasks.nim
+++ b/tasks.nim
@@ -689,23 +689,50 @@ task dist, "Build distribution":
   dist_prereqs_task()
   dist_package_task()
 
+proc generate_api_json() =
+  # jsondoc JSON consumed by the API reference pages in docs/book/api
+  let modules = [
+    ("ed", "deps/ed/src/ed/types.nim"),
+    ("ed/zens", "deps/ed/src/ed/zens/initializers.nim"),
+    ("ed/zens", "deps/ed/src/ed/zens/operations.nim"),
+    ("ed/zens", "deps/ed/src/ed/zens/contexts.nim"),
+    ("ed/zens", "deps/ed/src/ed/zens/validations.nim"),
+    ("enu", "share/vmlib/enu/types.nim"),
+    ("enu", "share/vmlib/enu/base_bridge.nim"),
+    ("enu", "share/vmlib/enu/base_api.nim"),
+    ("enu", "share/vmlib/enu/builds.nim"),
+    ("enu", "share/vmlib/enu/bots.nim"),
+    ("enu", "share/vmlib/enu/players.nim"),
+    ("enu", "share/vmlib/enu/signs.nim"),
+    ("enu", "share/vmlib/enu/state_machine.nim"),
+    ("enu", "share/vmlib/enu/worlds.nim"),
+    ("enu", "share/vmlib/enu/testing.nim"),
+  ]
+  for (out_sub, module) in modules:
+    let out_dir = "docs/book/api/json/" & out_sub
+    mk_dir out_dir
+    exec &"nim --hints:off --warnings:off jsondoc --outdir:{out_dir} {module}"
+
 task docs, "Build docs":
   exec "rm -rf dist/docs"
+  generate_api_json()
   with_dir "docs":
     exec "nim r book.nim init"
     exec "nim r book.nim build"
     exec "nim r ed.nim build"
   exec "cp -r docs/book/assets dist/docs"
-  exec "cp -r docs/assets/* dist/docs/assets/"
   exec "cp media/*.{png,webp} dist/docs/assets"
   exec "rm -rf dist/docs/assets/fonts"
   exec "mkdir -p dist/docs/assets/fonts"
   exec "cp -r fonts/jost dist/docs/assets/fonts/"
   exec "cp -r fonts/ibm dist/docs/assets/fonts/"
-  # Copy Ed docs to /ed/ for https://getenu.com/ed
+  # Copy Ed docs to /ed/ for https://getenu.com/ed. Keep the original file
+  # names too, since the baked-in sidebar links use them.
   exec "mkdir -p dist/docs/ed"
   exec "cp dist/docs/api/ed_readme.html dist/docs/ed/index.html"
+  exec "cp dist/docs/api/ed_readme.html dist/docs/ed/ed_readme.html"
   exec "cp dist/docs/api/ed_api.html dist/docs/ed/api.html"
+  exec "cp dist/docs/api/ed_api.html dist/docs/ed/ed_api.html"
 
 task export_docs, "Build docs and copy them to ../enu-site/docs":
   docs_task()

--- a/tests/vm/scripts/class_macros_test.nim
+++ b/tests/vm/scripts/class_macros_test.nim
@@ -2,7 +2,7 @@
 import std/[tables, macros]
 import testing
 import types
-import base_api
+import core
 import base_bridge
 import macro_helpers
 

--- a/tests/vm/scripts/position_a_tree.nim
+++ b/tests/vm/scripts/position_a_tree.nim
@@ -3,7 +3,7 @@
 ## constructor calls with position parameter.
 
 import std/[tables]
-import types, base_api, base_bridge
+import types, core, base_bridge
 
 var test_unit = Unit()
 test_unit.query_results = initTable[string, seq[Unit]]()

--- a/tests/vm/scripts/position_b_forest.nim
+++ b/tests/vm/scripts/position_b_forest.nim
@@ -3,7 +3,7 @@
 ## potentially corrupting the caller's register allocation.
 
 import std/[tables]
-import types, base_api, base_bridge, position_a_tree
+import types, core, base_bridge, position_a_tree
 
 var test_unit = Unit()
 test_unit.query_results = initTable[string, seq[Unit]]()

--- a/tests/vm/scripts/position_c_tree.nim
+++ b/tests/vm/scripts/position_c_tree.nim
@@ -5,7 +5,7 @@
 ##   if not is_instance: quit()
 
 import std/[tables]
-import types, state_machine, base_api, base_bridge, builds
+import types, state_machine, core, base_bridge, builds
 
 var test_unit = Unit()
 test_unit.query_results = initTable[string, seq[Unit]]()
@@ -96,7 +96,7 @@ proc run_script*(
   # script body:
   if not is_instance:
     enu_target.show = false
-    base_api.quit()
+    core.quit()
   sleep 0.0
 
 run_script(me, false)

--- a/tests/vm/scripts/position_d_forest.nim
+++ b/tests/vm/scripts/position_d_forest.nim
@@ -11,7 +11,7 @@
 ## the Tree.new calls here.
 
 import std/[tables]
-import types, state_machine, base_api, base_bridge, builds
+import types, state_machine, core, base_bridge, builds
 import position_c_tree
 
 var test_unit2 = Unit()

--- a/tests/vm/scripts/state_machine_test.nim
+++ b/tests/vm/scripts/state_machine_test.nim
@@ -2,7 +2,7 @@
 import std/tables
 import testing
 import state_machine
-import base_api
+import core
 import base_bridge
 import types
 

--- a/tests/vm/scripts/timing_test.nim
+++ b/tests/vm/scripts/timing_test.nim
@@ -1,6 +1,6 @@
 # Test Timestamp and Duration types
 import types
-import base_api
+import core
 
 # Test now() returns a Timestamp
 let t1 = now()

--- a/tests/vm/scripts/unittest_test.nim
+++ b/tests/vm/scripts/unittest_test.nim
@@ -1,6 +1,6 @@
 # Test custom testing framework in VM
 import testing
-import types
+import types, vectors
 
 suite "Vector3 with testing framework":
   test "vector creation":

--- a/tests/vm/scripts/vector3_test.nim
+++ b/tests/vm/scripts/vector3_test.nim
@@ -1,5 +1,5 @@
 # Test Vector3 operations
-import types
+import types, vectors
 
 # Test vector creation
 let v1 = vec3(1.0, 2.0, 3.0)


### PR DESCRIPTION
## Summary

- **Enu VM API reference** at [/docs/api/enu_api.html](https://getenu.com/docs/api/enu_api.html), generated from `share/vmlib/enu` doc comments via jsondoc and the existing Ed docs machinery. Linked from the book sidebar under Coding Enu.
- **Fixes the Ed API docs build**: jsondoc JSON is now generated from `deps/ed` by the `docs` task instead of read from the long-gone `../model_citizen` checkout, and `/docs/ed/` keeps the original page names so its sidebar links resolve.
- **vmlib restructure**: `types.nim` is just types; vector math moved to a new `vectors.nim`; `base_api.nim` became `core.nim`, which exports both. Every module/script wrapper imports `core`. (This also removes the duplicate TYPES section in the docs sidebar.)
- **Doc comments rewritten** across the scripting API in a conversational voice aimed at new programmers, with one comment per overload group.
- **API page UX**: collapsible persisted sidebar sections with Types-style `[+]/[-]` controls, modules collapsed by default, deep links reveal and center the symbol in the sidebar, module headers navigate to their section, inline code in descriptions colored, and every symbol/module links to its source on GitHub, pinned to the commit the docs were built from.
- Accuracy pass on the book: stale `nimble` commands, wrong `hit`/`rotation`/`sleep`/`speed` claims, `home` → `go_home`, R1 → L2 gamepad buttons, and a few more.

## Testing

- `nim test` green (unit + VM); VM test scripts updated for the module rename.
- Docs built with `nim docs`, published to getenu.com, and behaviors (collapse persistence, deep links, module nav) verified in Chrome.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01FUE9YWyJzcPBnycf4XMPLS