### PR TITLE
security: confine script file access to the level and work dirs

### DIFF
--- a/src/controllers/script_controllers/host_bridge.nim
+++ b/src/controllers/script_controllers/host_bridge.nim
@@ -13,7 +13,7 @@ import
 import libs/[interpreters, eval]
 import enu/shared/errors
 
-import ./[vars, scripting]
+import ./[vars, scripting, path_safety]
 include ./host_bridge_utils
 
 # Program start time for now_seconds() function
@@ -206,6 +206,15 @@ proc claim_name(self: Worker, requested: string) =
   if target_id == "" or thing.id == target_id:
     return
 
+  # `to_thing_id` lowercases but doesn't strip separators, so a name like
+  # `../../evil` would flow into the move_file/move_dir paths below and relocate
+  # this thing's script + data outside the level. Require a plain segment.
+  if not valid_path_component(target_id):
+    raise ValueError.init(
+      "Invalid name '" & requested &
+        "'. Names can't contain path separators or '..'."
+    )
+
   let
     new_script = state.config.script_dir / (target_id & ".nim")
     new_data_dir = state.config.data_dir / target_id
@@ -255,11 +264,39 @@ proc load_level(self: Worker, level: string, world: string) =
   var world = world
   if not ?world:
     world = state.config.world
+  # `change_loaded_level` joins world/level under work_dir with no checks, so a
+  # traversing name would point level_dir (and every subsequent load/save/reset)
+  # at an arbitrary directory. Keep both as plain segments so level_dir stays
+  # under work_dir/<world> (the world_dir).
+  if not valid_path_component(world) or not valid_path_component(level):
+    raise ValueError.init(
+      "Invalid level '" & world & "/" & level &
+        "'. World and level names must each be a single path segment " &
+        "with no '/' or '..'."
+    )
   self.exit(self.active_thing.script_ctx, 0)
   after_boop:
     change_loaded_level(level, world)
 
 proc reset_level(self: Worker) =
+  # reset_level deletes the level dir and relies on the bundled source being
+  # re-cloned on the next load (see serializers.load_level). Only levels that
+  # actually have a bundled source can be reset — otherwise the delete is
+  # unrecoverable. This mirrors load_level's clone-source detection.
+  let
+    base = state.config.lib_dir / "worlds" / state.config.world
+    bundled_level = base / state.config.level
+    world_template = state.config.world_dir / "template"
+    base_template = base / "template"
+  if not (
+    dir_exists(bundled_level) or dir_exists(world_template) or
+    dir_exists(base_template)
+  ):
+    raise ValueError.init(
+      "reset_level only works for levels bundled with Enu. '" &
+        state.config.world & "/" & state.config.level &
+        "' has no bundled source to restore from."
+    )
   self.exit(self.active_thing.script_ctx, 0)
   after_boop:
     let current_level = state.config.level_dir
@@ -1584,18 +1621,23 @@ proc bridge_to_vm*(worker: Worker) =
     "read_enu_script",
     proc(a: VmArgs) {.gcsafe.} =
       let filename = get_string(a, 0)
+      let level_dir = state.config_value.value.level_dir
       let full_path =
         if filename.is_absolute:
           filename
         else:
-          state.config_value.value.level_dir / "generated" / filename
+          level_dir / "generated" / filename
 
-      let normalized_path = full_path.replace("\\", "/").normalized_path()
-      debug "reading script source", path = normalized_path
-      if "/scripts/" notin normalized_path:
+      # Confine reads to the current level dir. The previous check only required
+      # the substring "/scripts/" anywhere in the path, which let an absolute
+      # path read any file under any dir named `scripts` (including other
+      # levels'). is_within canonicalizes both sides (symlinks + `..`), so
+      # read_file below resolves to the same file it validated.
+      debug "reading script source", path = full_path
+      if not is_within(level_dir, full_path):
         raise ValueError.init(
-          "Direct file access blocked for security. Scripts can only be read from within the scripts directory. Attempted: " &
-            normalized_path
+          "Direct file access blocked for security. Scripts can only be read " &
+            "from within the current level directory. Attempted: " & full_path
         )
       set_result(a, to_result(read_file(full_path)))
 

--- a/src/controllers/script_controllers/path_safety.nim
+++ b/src/controllers/script_controllers/path_safety.nim
@@ -1,0 +1,34 @@
+## Path-containment guards for script-supplied names and paths.
+##
+## Auto-loading level scripts pass world/level/thing names and file paths that
+## the host joins into real filesystem paths. These helpers keep those joins
+## from escaping their base directory — see the load_level, reset_level,
+## claim_name, and read_enu_script bridges in host_bridge.
+
+import std/[os, strutils]
+
+proc valid_path_component*(name: string): bool =
+  ## True if `name` is a single, non-traversing path segment: non-empty, not
+  ## `.`/`..`, not absolute, and free of path separators. Scripts supply
+  ## world/level/thing names that get joined into filesystem paths; requiring a
+  ## plain segment keeps those joins from escaping their base directory.
+  name.len > 0 and name != "." and name != ".." and '/' notin name and
+    '\\' notin name and not name.is_absolute
+
+proc is_within*(base, path: string): bool =
+  ## True if the fully-resolved `path` equals `base` or is nested under it.
+  ## Uses expand_filename so symlinks (e.g. macOS `/var` -> `/private/var`, which
+  ## the VM canonicalizes on one side but config.level_dir keeps on the other)
+  ## and `..` are resolved on both sides before the prefix comparison. A path
+  ## that can't be resolved (doesn't exist) is treated as outside — fail closed.
+  let b =
+    try:
+      base.expand_filename
+    except OSError, ValueError:
+      return false
+  let p =
+    try:
+      path.expand_filename
+    except OSError, ValueError:
+      return false
+  p == b or p.starts_with(b & $DirSep)

--- a/tasks.nim
+++ b/tasks.nim
@@ -171,6 +171,7 @@ task test_unit, "run unit tests":
   exec "nim c -r tests/unit/serializers_test"
   exec "nim c -r tests/unit/dependency_graph_test"
   exec "nim c -r tests/unit/tool_availability_test"
+  exec "nim c -r tests/unit/path_safety_test"
 
 task test_vm, "run VM script tests":
   exec "nim c -r tests/vm/runner"

--- a/tests/unit/path_safety_test.nim
+++ b/tests/unit/path_safety_test.nim
@@ -1,0 +1,71 @@
+## Regression tests for the script-sandbox path guards used by the load_level,
+## reset_level, claim_name, and read_enu_script host bridges. If these weaken,
+## a level script regains the ability to escape the level/work dir.
+
+import std/os
+import unittest2
+import controllers/script_controllers/path_safety
+
+suite "valid_path_component (load_level / claim_name guard)":
+  test "accepts plain world / level / thing names":
+    check valid_path_component("tutorial-1")
+    check valid_path_component("default")
+    check valid_path_component("build_tree")
+    check valid_path_component("bot_aqslupunw4ndq")
+
+  test "rejects empty and dot segments":
+    check not valid_path_component("")
+    check not valid_path_component(".")
+    check not valid_path_component("..")
+
+  test "rejects path separators and traversal":
+    check not valid_path_component("a/b")
+    check not valid_path_component("../evil")
+    check not valid_path_component("../../../../tmp/evil")
+    check not valid_path_component("foo/../bar")
+    check not valid_path_component("a\\b")
+
+  test "rejects absolute paths":
+    check not valid_path_component("/etc/passwd")
+
+proc make_fixture(): string =
+  ## root/level/scripts/foo.nim  (inside)   +   root/other/secret.txt (outside)
+  let root = get_temp_dir() / ("enu_path_safety_" & $get_current_process_id())
+  remove_dir(root)
+  create_dir(root / "level" / "scripts")
+  write_file(root / "level" / "scripts" / "foo.nim", "discard\n")
+  create_dir(root / "other")
+  write_file(root / "other" / "secret.txt", "secret\n")
+  root
+
+suite "is_within (read_enu_script confinement)":
+  test "accepts the level dir itself and nested files":
+    let root = make_fixture()
+    defer:
+      remove_dir(root)
+    let base = root / "level"
+    check is_within(base, base)
+    check is_within(base, base / "scripts")
+    check is_within(base, base / "scripts" / "foo.nim")
+
+  test "rejects a real file outside the level dir":
+    let root = make_fixture()
+    defer:
+      remove_dir(root)
+    let base = root / "level"
+    check not is_within(base, root / "other")
+    check not is_within(base, root / "other" / "secret.txt")
+
+  test "rejects traversal that escapes the level dir even to a real file":
+    let root = make_fixture()
+    defer:
+      remove_dir(root)
+    let base = root / "level"
+    check not is_within(base, base / ".." / "other" / "secret.txt")
+
+  test "fails closed on a path that does not exist":
+    let root = make_fixture()
+    defer:
+      remove_dir(root)
+    let base = root / "level"
+    check not is_within(base, base / "scripts" / "does_not_exist.nim")


### PR DESCRIPTION
## Summary

A security review of the Enu VM sandbox found that the base VM correctly blocks the classic escapes (arbitrary file r/w, `staticExec`/`gorge`, `slurp`/`staticRead`, FFI `importc`, env leaks — all verified failing in the VM). The real attack surface is the deliberately-bridged host procs, which join **script-supplied** names/paths into real filesystem paths with little or no containment. An auto-loading level script could exploit these to read/write/delete outside its own level directory.

This PR closes those escapes.

## Fixes

- **`load_level`** — rejects `world`/`level` names that aren't a single non-traversing path segment, so `level_dir` always stays under `work_dir/<world>`. (Previously `change_loaded_level` joined them into `work_dir` unchecked, allowing traversal to point `level_dir` — and every subsequent load/save/reset — at an arbitrary directory.)
- **`reset_level`** — only deletes a level that has a bundled source to restore from (mirrors `serializers.load_level`'s clone-source detection); otherwise raises without deleting. This also means an external `--level-dir` level is never wiped.
- **`read_enu_script`** — confines reads to the current level dir via a canonicalized (`expand_filename`) prefix check, replacing the weak `"/scripts/"` substring test, and reads the same path it validates. (The old check let an absolute path read any file under any dir named `scripts`, including other levels'.)
- **`claim_name`** — rejects names whose derived thing id would traverse out of the script/data dirs (`to_thing_id` didn't strip separators, so `name "../../evil"` could relocate a thing's script/data outside the level).

The two guards are extracted into `path_safety.nim` and covered by `tests/unit/path_safety_test.nim`.

Note: unrestricted `import` of internal/std modules from scripts (a defense-in-depth item) was intentionally left out of scope.

## Testing

- `nim build` clean
- `test_unit` (incl. new `path_safety_test`), `test_vm` (10/10), `test_world` (both levels exit 0, no false security blocks), `test_mcp` (all pass)
- Confirmed the confinement doesn't block legit build/bot script loading; caught and fixed a macOS `/var`→`/private/var` symlink issue via `expand_filename` along the way.