### PR TITLE
builds: default speed to `auto` — ramp up, then finish ASAP

### DIFF
--- a/share/vmlib/enu/base_bridge.nim
+++ b/share/vmlib/enu/base_bridge.nim
@@ -42,7 +42,9 @@ bridged_to_host:
 
   proc speed*(self: Thing): float
     ## How fast the thing moves or builds. `1` is normal, bigger is
-    ## faster, and `0` means "all at once" for building.
+    ## faster, and `ASAP` (`0`) means "all at once" for building. Builds
+    ## default to `auto`, which starts slow and speeds up before finishing
+    ## ASAP.
 
   proc `speed=`*(self: Thing, speed: float)
   proc scale*(self: Thing): float

--- a/share/vmlib/enu/class_macros.nim
+++ b/share/vmlib/enu/class_macros.nim
@@ -115,7 +115,10 @@ proc build_ctors(
 
   var speed = "speed".ident
   if "speed" notin var_names:
-    params &= new_ident_defs(speed, new_empty_node(), new_float_lit_node(1.0))
+    # Instances default to ASAP: a spawned copy appears at once (you already
+    # watched the prototype draw itself). Prototypes and standalone script
+    # builds keep the `auto` ramp from their base default.
+    params &= new_ident_defs(speed, new_empty_node(), ident"ASAP")
   ctor_body.add quote do:
     result.speed = `speed`
 

--- a/share/vmlib/enu/core.nim
+++ b/share/vmlib/enu/core.nim
@@ -465,7 +465,7 @@ template move*[T: Thing](new_enu_target: T) =
     enu_target.end_asap()
   enu_target = new_enu_target
   move_mode = 2
-  if enu_target.speed == 0:
+  if enu_target.speed == 0 or enu_target.speed == auto:
     enu_target.speed = 1
 
 template build*(new_enu_target: Thing) =

--- a/share/vmlib/enu/types.nim
+++ b/share/vmlib/enu/types.nim
@@ -8,6 +8,11 @@ const ASAP* = 0.0
   ## Magic speed value. `speed = ASAP` makes a build draw everything at
   ## once instead of block by block.
 
+const auto* = float.high
+  ## The default build speed. `speed = auto` starts slow and speeds the
+  ## drawing up over a few seconds, then finishes the rest all at once
+  ## (`ASAP`). Set a plain number for a steady speed instead.
+
 type
   Vector3* = tuple[x, y, z: float]
     ## A spot (or a direction) in the world. `x` is left/right, `y` is

--- a/src/controllers/script_controllers/host_bridge.nim
+++ b/src/controllers/script_controllers/host_bridge.nim
@@ -643,12 +643,26 @@ proc speed(self: Thing): float =
 const ASAP_VALUE = 0
 
 proc `speed=`(self: Thing, speed: float) =
-  if self of Build and speed == ASAP_VALUE:
-    Build(self).begin_asap()
-    types.`speed=`(self, 0.0)
+  if self of Build:
+    let build = Build(self)
+    if speed == ASAP_VALUE:
+      build.auto_ramp_active = false
+      build.begin_asap()
+      types.`speed=`(self, 0.0)
+    elif speed == AUTO:
+      types.`speed=`(self, AUTO)
+      # Don't restart a ramp that already finished — e.g. an `asap:` block
+      # captures `auto`, sets ASAP, then restores `auto` when it exits.
+      if build.auto_ramp_done:
+        build.begin_asap()
+        build.voxels_per_frame = float.high
+      else:
+        build.arm_auto_ramp()
+    else:
+      build.auto_ramp_active = false
+      build.end_asap()
+      types.`speed=`(self, speed)
   else:
-    if self of Build:
-      Build(self).end_asap()
     types.`speed=`(self, speed)
 
 proc scale(self: Thing): float =

--- a/src/controllers/script_controllers/worker.nim
+++ b/src/controllers/script_controllers/worker.nim
@@ -46,6 +46,7 @@ proc advance_thing(self: Worker, thing: Thing, timeout: MonoTime): bool =
       thing.current_line = ctx.current_line.line.int
     if thing of Build:
       let thing = Build(thing)
+      thing.update_auto_ramp()
       thing.voxels_remaining_this_frame += thing.voxels_per_frame
     try:
       assert self.active_thing.is_nil
@@ -164,6 +165,12 @@ proc change_code(self: Worker, thing: Thing, code: Code) =
       discard
   elif code.nim.strip != "":
     debug "loading thing", thing_id = thing.id
+    # A live run (the editor or a file-watch save, never a level/reload which
+    # sets LOADING_SCRIPT) arms the auto-speed ramp so the build visibly draws
+    # itself. Loads stay in ASAP and just appear.
+    if thing of Build and LOADING_SCRIPT notin state.local_flags and
+        Build(thing).speed == AUTO:
+      Build(thing).arm_auto_ramp()
     if LOADING_SCRIPT notin state.local_flags and not self.retry_failures:
       thing.write_script_file(code.nim)
       if not self.interpreter.is_nil:

--- a/src/models/builds.nim
+++ b/src/models/builds.nim
@@ -1,7 +1,7 @@
 import
   std/[
-    tables, sets, options, sequtils, math, monotimes, sugar, macros, strformat,
-    strutils, os,
+    tables, sets, options, sequtils, math, monotimes, times, sugar, macros,
+    strformat, strutils, os,
   ]
 import godotapi/spatial
 import core, models/[states, bots, colors, things, voxels]
@@ -16,6 +16,17 @@ export things
 include "build_code_template.nim.nimf"
 
 const default_color = ACTION_COLORS[BLUE]
+
+const
+  AUTO* = float.high
+    ## The default build speed. Must match `auto` in the VM's `enu/types`
+    ## (both `float.high`) so a script's `speed = auto` round-trips to the
+    ## same value the host tests here.
+  AUTO_RAMP_SECONDS = 3.0
+    ## How long the auto ramp takes to reach full speed before handing off
+    ## to ASAP.
+  AUTO_RAMP_START_SPEED = 1.0
+  AUTO_RAMP_END_SPEED = 50.0
 
 var
   current_build* {.threadvar.}: Build
@@ -149,6 +160,37 @@ proc end_asap*(self: Build) {.gcsafe.} =
     self.voxels.flush_dirty_chunks()
     self.reset_bounds()
     self.global_flags -= ASAP_MODE
+
+proc arm_auto_ramp*(self: Build) {.gcsafe.} =
+  ## Start a fresh `speed = auto` ramp: leave ASAP so blocks appear as they're
+  ## drawn, and begin at the slow end. The clock starts on the first drawn
+  ## block (`on_begin_move`), the rate climbs each frame (`update_auto_ramp`),
+  ## and after `AUTO_RAMP_SECONDS` it hands the rest to ASAP.
+  self.auto_ramp_active = true
+  self.auto_ramp_started = false
+  self.auto_ramp_done = false
+  self.voxels_per_frame = AUTO_RAMP_START_SPEED
+  self.voxels_remaining_this_frame = 0
+  self.end_asap()
+
+proc update_auto_ramp*(self: Build) {.gcsafe.} =
+  ## Advance the auto ramp one frame: set the per-frame voxel budget from an
+  ## ease-in curve (slow at first) between the start and end speeds, then flip
+  ## to ASAP once the ramp's time is up. A no-op unless a ramp is running and
+  ## the first block has anchored the clock.
+  if not (self.auto_ramp_active and self.auto_ramp_started):
+    return
+  let elapsed =
+    (get_mono_time() - self.auto_ramp_start).in_microseconds.float / 1_000_000.0
+  if elapsed >= AUTO_RAMP_SECONDS:
+    self.auto_ramp_active = false
+    self.auto_ramp_done = true
+    self.begin_asap()
+    self.voxels_per_frame = float.high
+  else:
+    let t = elapsed / AUTO_RAMP_SECONDS
+    self.voxels_per_frame =
+      AUTO_RAMP_START_SPEED + (AUTO_RAMP_END_SPEED - AUTO_RAMP_START_SPEED) * t * t
 
 template buffer*(self: Build, body: untyped) =
   ## Batch many draws into a single flush. `draw` normally syncs each voxel,
@@ -397,7 +439,14 @@ method on_begin_move*(
           self.transform.origin + (moving * self.speed * delta)
         return RUNNING
   else:
-    if self.speed == 0:
+    if self.speed == AUTO and self.auto_ramp_active:
+      # Anchor the ramp clock to the first drawn block; update_auto_ramp drives
+      # voxels_per_frame from here on.
+      if not self.auto_ramp_started:
+        self.auto_ramp_started = true
+        self.auto_ramp_start = get_mono_time()
+    elif self.speed == 0 or self.speed == AUTO:
+      # ASAP, or auto with no ramp armed (e.g. a level load): draw it all.
       self.voxels_per_frame = float.high
     else:
       self.voxels_remaining_this_frame = self.speed
@@ -474,7 +523,10 @@ method reset*(self: Build) =
   debug "resetting build", id = self.id
   self.transform = self.start_transform
   self.color = self.start_color
-  self.speed = 0 # draw ASAP unless the script sets a speed
+  self.speed = AUTO # ramp up then finish ASAP, unless the script sets a speed
+  self.auto_ramp_active = false
+  self.auto_ramp_started = false
+  self.auto_ramp_done = false
   self.begin_asap()
   self.scale = 1
 

--- a/src/types.nim
+++ b/src/types.nim
@@ -433,6 +433,14 @@ type
     turtle_transform_value*: EdValue[Transform]
     voxels_per_frame*: float
     voxels_remaining_this_frame*: float
+    # `speed = auto` ramp state (see builds.nim). `active` while the draw rate
+    # is ramping up, `started` once the first block anchors the clock, `done`
+    # after it has handed off to ASAP — so a later `speed = auto` (e.g. an
+    # `asap:` block restoring the speed) doesn't restart a finished ramp.
+    auto_ramp_active*: bool
+    auto_ramp_started*: bool
+    auto_ramp_done*: bool
+    auto_ramp_start*: MonoTime
     drawing*: bool
     bounds_value*: EdValue[AABB]
     bot_collisions*: bool

--- a/tasks.nim
+++ b/tasks.nim
@@ -171,6 +171,7 @@ task test_unit, "run unit tests":
   exec "nim c -r tests/unit/voxel_packing_test"
   exec "nim c -r tests/unit/json_loading_test"
   exec "nim c -r tests/unit/serializers_test"
+  exec "nim c -r tests/unit/build_speed_test"
   exec "nim c -r tests/unit/dependency_graph_test"
   exec "nim c -r tests/unit/tool_availability_test"
   exec "nim c -r tests/unit/path_safety_test"

--- a/tests/unit/build_speed_test.nim
+++ b/tests/unit/build_speed_test.nim
@@ -1,0 +1,51 @@
+import unittest2
+import std/[monotimes, times]
+import core
+import models
+import models/builds {.all.}
+
+suite "Build auto speed":
+  test "builds default to auto speed":
+    let build = Build.init(id = "build_auto_default")
+    check build.speed == AUTO
+
+  test "arming a ramp leaves ASAP and starts at the slow end":
+    let build = Build.init(id = "build_auto_arm")
+    build.arm_auto_ramp()
+    check build.auto_ramp_active
+    check not build.auto_ramp_started
+    check not build.auto_ramp_done
+    check build.voxels_per_frame == AUTO_RAMP_START_SPEED
+    check ASAP_MODE notin build.global_flags
+
+  test "the ramp eases in — slower than linear at the midpoint":
+    let build = Build.init(id = "build_auto_curve")
+    build.arm_auto_ramp()
+    build.auto_ramp_started = true
+    # Pretend half of the ramp's time has elapsed.
+    build.auto_ramp_start =
+      get_mono_time() + init_duration(milliseconds = -1500)
+    build.update_auto_ramp()
+    check build.auto_ramp_active
+    let linear_mid = (AUTO_RAMP_START_SPEED + AUTO_RAMP_END_SPEED) / 2
+    check build.voxels_per_frame > AUTO_RAMP_START_SPEED
+    check build.voxels_per_frame < linear_mid
+
+  test "the ramp hands off to ASAP once its time is up":
+    let build = Build.init(id = "build_auto_done")
+    build.arm_auto_ramp()
+    build.auto_ramp_started = true
+    build.auto_ramp_start = get_mono_time() + init_duration(seconds = -4)
+    build.update_auto_ramp()
+    check not build.auto_ramp_active
+    check build.auto_ramp_done
+    check build.voxels_per_frame == float.high
+    check ASAP_MODE in build.global_flags
+
+  test "an un-armed auto build stays in ASAP (level-load path)":
+    let build = Build.init(id = "build_auto_unarmed")
+    # No arm: update is a no-op and the build keeps ASAP's batched meshing.
+    check not build.auto_ramp_active
+    build.update_auto_ramp()
+    check not build.auto_ramp_active
+    check ASAP_MODE in build.global_flags


### PR DESCRIPTION
## What

Adds a new magic build speed, `auto` (`float.high`), and makes it the **default for standalone script builds and prototypes**. `ASAP` stays `0`.

Such a build starts drawing at **speed 1** and eases up to **speed 50 over 3 seconds** on a quadratic curve (slow at first), then switches to **ASAP** to dump whatever's left. Set a plain number for a steady speed as before.

**Defaults, per the design settled in review:**
| Kind | Default | Behavior |
|------|---------|----------|
| Standalone script build | `auto` | ramps, then ASAP |
| Prototype | `auto` | ramps, then ASAP |
| Instance (`Foo.new(...)`) | `ASAP` | appears at once |

No build defaults to speed 1 anymore. `move me` movement speed is untouched — this only changes **draw** speed.

## How it works

- **`share/vmlib/enu/types.nim`** — `const auto* = float.high`, exposed to scripts alongside `ASAP`.
- **`share/vmlib/enu/class_macros.nim`** — the generated instance constructor now defaults `speed` to `ASAP` (was `1.0`); the prototype build itself keeps the base `auto` default.
- **`src/models/builds.nim`** — `arm_auto_ramp` / `update_auto_ramp` drive the per-frame voxel budget from the ease-in curve; `reset` defaults builds to `auto`.
- **`src/controllers/.../worker.nim`** — `advance_thing` ticks the ramp each frame; `change_code` arms it only on interactive runs.
- **`src/controllers/.../host_bridge.nim`** — `speed=` arms/disarms the ramp when a script sets `auto` / a number / `ASAP`.
- **`share/vmlib/enu/core.nim`** — `move` bumps `auto`/`ASAP` to `1` so moving a build isn't an instant teleport (movement speed unchanged from before).

## Design notes

- **Loads stay instant.** The ramp only arms on interactive runs (in-editor edits, file-watch saves). Level loads and reloads run under `LOADING_SCRIPT` and stay in ASAP, so every build in a level appears at once — no animate-in on load.
- **A finished ramp isn't restarted** when speed is set back to `auto` — e.g. an `asap:` block captures `auto`, sets ASAP, then restores `auto` on exit. Tracked via `auto_ramp_done`.

## Testing

- New `tests/unit/build_speed_test.nim` (5 cases): default is `auto`; arming leaves ASAP and starts slow; the curve is slower than linear at the midpoint (ease-in); handoff to ASAP after 3s; an un-armed build stays in ASAP (load path).
- `nim test` (unit + vm) green — including the instance/prototype VM tests (`position_b_forest` etc.); full `nim build` succeeds.
- Not yet eyeballed live in-app — worth a quick manual look at a build drawing.