### PR TITLE
ui: list shipped levels in the level picker

### DIFF
--- a/src/ui/settings.nim
+++ b/src/ui/settings.nim
@@ -63,12 +63,31 @@ gdobj Settings of PanelContainer:
 
   proc update_level_list() =
     self.levels.clear()
-    if not ?state.config.connect_address:
-      self.levels.add_item("New...")
-      for file in walk_dirs(state.config.world_dir / "*"):
-        let world = file.split_file.name
-        if world != "backups":
-          self.levels.add_item(world)
+    if ?state.config.connect_address:
+      return
+    self.levels.add_item("New...")
+
+    # The picker is a deduped union of the levels created locally and the
+    # levels Enu ships for the current world. A shipped level that hasn't been
+    # opened yet has no local copy — loading it copies it in (see load_level) —
+    # but it should still be selectable here. World can't change in the UI, so
+    # we only ever list the current world's levels.
+    var names: seq[string]
+    for dir in walk_dirs(state.config.world_dir / "*"):
+      let name = dir.split_file.name
+      if name notin ["backups", "template"]:
+        names.add name
+
+    let shipped_dir = state.config.lib_dir / "worlds" / state.config.world
+    for dir in walk_dirs(shipped_dir / "*"):
+      let name = dir.split_file.name
+      # Only real levels: skip the world template and non-level dirs (course
+      # authoring projects, backups) that lack a level.json.
+      if name notin ["backups", "template"] and file_exists(dir / "level.json"):
+        names.add name
+
+    for name in names.sorted.deduplicate(is_sorted = true):
+      self.levels.add_item(name)
 
   method ready*() =
     with self:


### PR DESCRIPTION
## What

The level picker (Settings) now lists a **deduped union of local and shipped levels** for the current world, instead of only the levels that already exist locally.

Enu ships canned levels under `share/worlds/<world>/`. Loading one that doesn't exist locally copies it into your data dir as a starting point (see `load_level` in `serializers.nim`) — but until now those shipped levels were invisible in the picker unless you'd already opened them. This surfaces them so you can pick a shipped level directly; selecting it triggers the existing copy-on-load path.

## Details

- Only the **current world**'s levels are listed (the world can't be changed from the UI).
- Shipped entries are filtered to real levels: a directory must contain `level.json`. This excludes the world `template`, `backups`, and non-level dirs such as course authoring projects (e.g. `course/loops`).
- Local levels keep their existing filtering (`backups`/`template` excluded); the merged list is sorted and deduplicated so a locally-copied shipped level appears once.

## Verification

- `nim build` and `nim test` pass.
- Ran the enumeration logic against the real `share/worlds` tree plus a simulated local dir:
  - `tutorial` with no local levels → `hour-of-code, tutorial-1, tutorial-2, tutorial-3` (the feature).
  - `course` / `default` → empty (authoring project, backups, template correctly excluded).
  - local `{tutorial-1, my-custom-level, backups}` + shipped tutorial → `hour-of-code, my-custom-level, tutorial-1, tutorial-2, tutorial-3` (dedup + exclusion confirmed).

🤖 Generated with [Claude Code](https://claude.com/claude-code)