### PR TITLE
Engine fixes: frame-animation pipeline, load path, prefill unification

### DIFF
--- a/bin/demos/demo_island.nim
+++ b/bin/demos/demo_island.nim
@@ -1,0 +1,881 @@
+## Generates the 0.3 course level terrain: a U of cliffs (east, west, south),
+## a waterfall on the west cliff feeding a river that runs east and bends
+## north into the sea, a large island in the mouth, a second land mass to the
+## north-west, and open sea to the northern horizon. Same look/vocabulary as
+## demo_sea (noise, palette, palms).
+##
+## Two builds so the water can animate later without re-baking the land:
+## `build_terrain` (land + cliffs, static forever) and `build_water`
+## (sea + river + falls). Static for now.
+##
+## Env overrides: ISL_ADDR (host:port of a listening Enu), ISL_SAVE=1
+## (persist with the level — stable ids; kill any prior run first),
+## ISL_PACE (seconds between emit bands).
+import std/[math, os, strutils]
+import client
+import core, models/[builds, things, colors, voxels]
+
+proc env_f(name: string, default: float): float =
+  let v = get_env(name)
+  if v == "": default else: v.parse_float
+
+let
+  SAVE = get_env("ISL_SAVE") == "1"
+  PACE = env_f("ISL_PACE", 0.3)
+  ADDR = get_env("ISL_ADDR")
+  FRAMES = int(env_f("ISL_FRAMES", 0)) # >0: flipbook of N water frames
+  LOOP = env_f("ISL_LOOP", 3.0) # seconds per animation loop
+  FRAME_PACE = env_f("ISL_FRAME_PACE", 1.5) # settle time between frames
+
+const
+  SEA_BASE = 1.1 # mean water surface height, metres above ground
+  SEED = 11'u32
+  KIND = PERSISTED
+
+  # Play footprint: land only exists inside it; sea reaches the plane edge.
+  X0 = -260.0
+  X1 = 260.0
+  Z0 = -320.0
+  Z1 = 180.0
+  G = 500 # grid half-extent; the ground plane runs to ±500
+  DIM = 2 * G
+
+  CLIFF_H = 45.0
+  WEST_X = -230.0 # inner edges of the cliff bands
+  EAST_X = 230.0
+  SOUTH_Z = 150.0
+
+# --- deterministic noise (demo_sea) ------------------------------------------
+
+proc hash01(ix, iz: int, salt: uint32): float =
+  var h =
+    cast[uint32](ix) * 0x85ebca6b'u32 xor cast[uint32](iz) * 0xc2b2ae35'u32 xor
+    (salt * 0x9e3779b9'u32 + SEED)
+  h = h xor (h shr 13)
+  h = h * 0x27d4eb2f'u32
+  h = h xor (h shr 16)
+  float(h and 0xffffff'u32) / float(0xffffff)
+
+proc smooth(t: float): float =
+  t * t * (3.0 - 2.0 * t)
+
+proc vnoise(x, z: float, salt: uint32): float =
+  ## Value noise in [0, 1].
+  let
+    ix = floor(x).int
+    iz = floor(z).int
+    fx = smooth(x - floor(x))
+    fz = smooth(z - floor(z))
+    a = hash01(ix, iz, salt)
+    b = hash01(ix + 1, iz, salt)
+    c = hash01(ix, iz + 1, salt)
+    d = hash01(ix + 1, iz + 1, salt)
+  (a * (1 - fx) + b * fx) * (1 - fz) + (c * (1 - fx) + d * fx) * fz
+
+proc fbm(x, z: float, salt: uint32, octaves = 4): float =
+  ## Fractal noise in [0, 1].
+  var
+    total = 0.0
+    amp = 1.0
+    norm = 0.0
+    fx = x
+    fz = z
+  for o in 0 ..< octaves:
+    total += vnoise(fx, fz, salt + uint32(o) * 101) * amp
+    norm += amp
+    amp *= 0.5
+    fx = fx * 2.03 + 17.3
+    fz = fz * 2.03 - 9.1
+  total / norm
+
+# --- waves (demo_sea, static time) --------------------------------------------
+
+var sea_time = 0.0
+
+proc dir_wave(x, z, wavelength, angle_deg, phase: float): float =
+  ## A plane wave with deep-water dispersion. In flipbook mode each speed is
+  ## snapped a few percent so the wave completes whole cycles in LOOP seconds
+  ## — frame N-1 wraps seamlessly to frame 0 (demo_sea's trick).
+  let
+    a = angle_deg * PI / 180.0
+    k = 2.0 * PI / wavelength
+  var speed = sqrt(9.81 * wavelength / (2.0 * PI))
+  if FRAMES > 0:
+    let cycles = max(1.0, round(speed * LOOP / wavelength))
+    speed = cycles * wavelength / LOOP
+  sin((x * cos(a) + z * sin(a)) * k - k * speed * sea_time + phase)
+
+proc river_flow_streak(x, z: float): float =
+  ## Falls-style foam pattern for the river surface: static lanes carrying
+  ## foam lines, plus dashes and longer streaks sliding downstream (west ->
+  ## east) at 16 m/s — 2 voxels per frame. The pattern grid wraps at P and
+  ## 24 frames x 2 voxels = one full wrap, so the loop is exact.
+  const P = 48
+  let
+    drift = if FRAMES > 0: P.float * sea_time / LOOP else: 0.0
+    xw = ((int(floor(x - drift)) mod P) + P) mod P
+    zi = int(floor(z))
+    lane = fbm(z * 0.9, 15.3, 97, 2) # which lanes carry foam lines
+    dash = hash01(zi, xw div 3, 98) # short dashes sliding east
+    run = hash01(zi * 7, xw div 8, 99) # longer streaks
+  if lane > 0.62:
+    result += 0.35
+  elif lane > 0.55:
+    result += 0.15
+  if dash > 0.80:
+    result += 0.35
+  if run > 0.86:
+    result += 0.3
+  result = clamp(result, 0.0, 1.0)
+
+proc wave_height(x, z: float): float =
+  ## Sea surface offset in metres, roughly [-1, 1]. In flipbook mode the
+  ## noise fields drift in a small circle so they loop with LOOP.
+  var wx, wz: float
+  if FRAMES > 0:
+    let phase = 2.0 * PI * sea_time / LOOP
+    wx = x + 1.5 * (cos(phase) - 1.0)
+    wz = z + 1.5 * sin(phase)
+  else:
+    wx = x + sea_time * 1.1
+    wz = z + sea_time * 0.4
+  let groups = 0.4 + 0.6 * vnoise(wx / 26.0, wz / 26.0, 40)
+  result = 0.42 * dir_wave(x, z, 43.0, 20.0, 0.0)
+  result += 0.30 * dir_wave(x, z, 17.0, -35.0, 1.7)
+  result += 0.20 * groups * dir_wave(x, z, 7.2, 65.0, 4.1)
+  result += 0.18 * (fbm(wx / 3.1, wz / 3.1, 50, 3) - 0.5)
+
+# --- layout --------------------------------------------------------------------
+
+proc coast_z(x: float): float =
+  ## Sea everywhere north of this line: NW headland to the NE river mouth.
+  -250.0 + (x + 260.0) * (180.0 / 520.0) +
+    44.0 * (fbm(x / 57.0, 3.7, 42, 3) - 0.5)
+
+const RIVER = [
+  (-238.0, -55.0),
+  (-150.0, -50.0),
+  (-40.0, -60.0),
+  (70.0, -66.0),
+  (135.0, -92.0),
+  (172.0, -128.0),
+]
+
+proc river_dist(x, z: float): tuple[d, t: float] =
+  ## Distance to the river centerline and normalized position along it.
+  result = (1e9, 0.0)
+  var run = 0.0
+  var total = 0.0
+  for i in 0 ..< RIVER.len - 1:
+    total += sqrt(
+      (RIVER[i + 1][0] - RIVER[i][0]) ^ 2 + (RIVER[i + 1][1] - RIVER[i][1]) ^ 2
+    )
+  for i in 0 ..< RIVER.len - 1:
+    let
+      ax = RIVER[i][0]
+      az = RIVER[i][1]
+      bx = RIVER[i + 1][0]
+      bz = RIVER[i + 1][1]
+      seg = sqrt((bx - ax) ^ 2 + (bz - az) ^ 2)
+      t = clamp(((x - ax) * (bx - ax) + (z - az) * (bz - az)) / (seg * seg), 0.0, 1.0)
+      px = ax + t * (bx - ax)
+      pz = az + t * (bz - az)
+      d = sqrt((x - px) ^ 2 + (z - pz) ^ 2)
+    if d < result.d:
+      result = (d, (run + t * seg) / total)
+    run += seg
+
+proc river_halfwidth(t: float): float =
+  11.0 + 26.0 * t
+
+const
+  ISL_CX = 195.0
+  ISL_CZ = -215.0
+  ISL_R = 52.0
+  ISL_TALL = 14.0
+
+proc island_elev(x, z: float): float =
+  ## Metres above (positive) or below (negative, capped) sea level.
+  let
+    dx = x - ISL_CX
+    dz = z - ISL_CZ
+    d = sqrt(dx * dx + dz * dz)
+    wobble = 0.7 + 0.6 * fbm(x / 45.0 + ISL_CX, z / 45.0 + ISL_CZ, 60, 3)
+    rr = ISL_R * wobble
+    t = 1.0 - d / rr
+  if t > -0.6:
+    if t > 0:
+      ISL_TALL * pow(t, 1.6) + 2.8 * t * (fbm(x / 9.0, z / 9.0, 70, 3) - 0.4)
+    else:
+      t * 3.0 # underwater skirt
+  else:
+    -2.0
+
+proc cliff_elev(x, z: float): float =
+  ## Height of the cliff field: 0 on open land, rising to ~CLIFF_H in the
+  ## border bands. Fades to nothing as the bands run into the sea (headlands).
+  let
+    ww = 8.0 * (fbm(z / 33.0, 7.1, 43, 3) - 0.5) * 2.0
+    we = 8.0 * (fbm(z / 33.0, 19.9, 44, 3) - 0.5) * 2.0
+    ws = 8.0 * (fbm(x / 33.0, 31.3, 45, 3) - 0.5) * 2.0
+    cd = max(max((WEST_X + ww) - x, x - (EAST_X + we)), z - (SOUTH_Z + ws))
+  if cd <= 0:
+    return 0.0
+  let
+    tall = CLIFF_H + 16.0 * (fbm(x / 24.0, z / 24.0, 46, 3) - 0.5)
+    # headlands keep their height past the coastline and plunge into the
+    # sea ~40 m out, so there's no walkable strip around the cliff ends
+    fade = smooth(clamp((z - (coast_z(x) - 40.0)) / 50.0, 0.0, 1.0))
+  tall * smooth(clamp(cd / 16.0, 0.0, 1.0)) * fade
+
+proc meadow_elev(x, z: float): float =
+  1.6 + 3.2 * fbm(x / 41.0, z / 41.0, 70, 3)
+
+const
+  FALLS_X = -230.0 # base of the west cliff at the river head
+  FALLS_Z = -55.0
+
+proc falls_streak(z, y, phase_x: float): float =
+  ## Curtain foam intensity in [0, 1]: static vertical foam lines (a
+  ## per-column bias) plus random flecks and longer runs falling 16 m/s —
+  ## 2 voxels per frame. The fleck grid wraps every P rows, and 24 frames x
+  ## 2 voxels = 2 full wraps, so the loop is exact while staying genuinely
+  ## random (integer drop per frame keeps features falling coherently).
+  const P = 24
+  let
+    drop = if FRAMES > 0: 2.0 * P.float * sea_time / LOOP else: 0.0
+    zi = int(floor(z)) * 31 + int(phase_x * 5.0)
+    yw = ((int(floor(y + drop)) mod P) + P) mod P
+    col = fbm(z * 1.1, 4.7, 94, 2) # which columns carry foam lines
+    fleck = hash01(zi, yw div 2, 95) # short falling flecks
+    run = hash01(zi * 7, yw div 6, 96) # longer falling runs
+  if col > 0.60:
+    result += 0.45
+  elif col > 0.52:
+    result += 0.2
+  if fleck > 0.72:
+    result += 0.35
+  if run > 0.8:
+    result += 0.3
+  result = clamp(result, 0.0, 1.0)
+
+# --- colors (demo_sea palette + rock) -------------------------------------------
+
+proc quant(v: float32): float32 =
+  round(v * 32.0) / 32.0
+
+proc mix(a, b: Color, t: float): Color =
+  let t = clamp(t, 0.0, 1.0)
+  Color(
+    r: quant(a.r + (b.r - a.r) * t),
+    g: quant(a.g + (b.g - a.g) * t),
+    b: quant(a.b + (b.b - a.b) * t),
+    a: 1.0,
+  )
+
+let
+  deep_water = col"082f66"
+  mid_water = col"1565c0"
+  crest_water = col"3f9be8"
+  shallow_water = col"46c6b8"
+  foam = col"f2f8fc"
+  wet_sand = col"b39c6b"
+  dry_sand = col"e8d9a6"
+  low_grass = col"6fbf4e"
+  high_grass = col"3e8a30"
+  rock = col"7d6a55"
+  trunk_col = col"6b4a2e"
+  palm_col = col"2f7d32"
+  rock_dark = col"46392c"
+  rock_mid = col"6e5a41"
+  rock_light = col"93805f"
+  shade_grass = col"2e7226"
+  charcoal = col"3d3630"
+  birch = col"d9cbb0"
+  conifer_green = col"235e2b"
+
+let
+  FLOWERS = [col"f2f2f2", col"e06060", col"ffd23d", col"a06de0"]
+  PALM_GREENS = [col"2f7d32", col"3f9138", col"25702c"]
+  LEAF_GREENS = [col"3c8f30", col"58a13c", col"2f7d32"]
+  TRUNKS = [trunk_col, charcoal, birch]
+
+# --- grids ----------------------------------------------------------------------
+
+type ColKind = enum
+  NONE
+  LAND
+  WATER
+
+var
+  kind_g = new_seq[ColKind](DIM * DIM)
+  top = new_seq[int16](DIM * DIM)
+  elev = new_seq[float32](DIM * DIM) # land: metres above sea level
+  wave = new_seq[float32](DIM * DIM) # water: surface offset
+  cliff = new_seq[float32](DIM * DIM) # land: cliff field height
+  open_sea = new_seq[float32](DIM * DIM) # 0 = river, 1 = open water
+  shore = new_seq[float32](DIM * DIM) # water: distance to nearest land
+
+template idx(ix, iz: int): int =
+  ix * DIM + iz
+
+template wxf(ix: int): float =
+  float(ix - G)
+
+template wzf(iz: int): float =
+  float(iz - G)
+
+proc classify() =
+  for ix in 0 ..< DIM:
+    for iz in 0 ..< DIM:
+      let
+        x = wxf(ix)
+        z = wzf(iz)
+        i = idx(ix, iz)
+        in_footprint = x >= X0 and x < X1 and z >= Z0 and z < Z1
+        ie = island_elev(x, z)
+      if ie > 0.05:
+        kind_g[i] = LAND
+        elev[i] = ie
+        continue
+      let
+        c = coast_z(x)
+        (rd, rt) = river_dist(x, z)
+        rdw = rd + 4.0 * (fbm(x / 17.0, z / 17.0, 55, 3) - 0.5) * 2.0
+      let cl = if in_footprint: cliff_elev(x, z) else: 0.0
+      if rdw < river_halfwidth(rt):
+        kind_g[i] = WATER
+        open_sea[i] = clamp((c - z) / 35.0, 0.0, 1.0)
+      elif cl > 2.0:
+        # headlands extend into the sea as rock
+        kind_g[i] = LAND
+        cliff[i] = cl
+        elev[i] = meadow_elev(x, z)
+      elif z < c:
+        kind_g[i] = WATER
+        open_sea[i] = clamp((c - z) / 35.0, 0.0, 1.0)
+      elif in_footprint:
+        kind_g[i] = LAND
+        cliff[i] = cl
+        elev[i] = meadow_elev(x, z)
+
+proc chamfer(target: ColKind, dist: var seq[float32]) =
+  ## Distance in metres from every column to the nearest column of `target`.
+  const BIG = 1e9'f32
+  for i in 0 ..< DIM * DIM:
+    dist[i] = if kind_g[i] == target: 0.0 else: BIG
+  for ix in 0 ..< DIM:
+    for iz in 0 ..< DIM:
+      let i = idx(ix, iz)
+      if ix > 0:
+        dist[i] = min(dist[i], dist[idx(ix - 1, iz)] + 1.0)
+        if iz > 0:
+          dist[i] = min(dist[i], dist[idx(ix - 1, iz - 1)] + 1.41)
+        if iz < DIM - 1:
+          dist[i] = min(dist[i], dist[idx(ix - 1, iz + 1)] + 1.41)
+      if iz > 0:
+        dist[i] = min(dist[i], dist[idx(ix, iz - 1)] + 1.0)
+  for ix in countdown(DIM - 1, 0):
+    for iz in countdown(DIM - 1, 0):
+      let i = idx(ix, iz)
+      if ix < DIM - 1:
+        dist[i] = min(dist[i], dist[idx(ix + 1, iz)] + 1.0)
+        if iz > 0:
+          dist[i] = min(dist[i], dist[idx(ix + 1, iz - 1)] + 1.41)
+        if iz < DIM - 1:
+          dist[i] = min(dist[i], dist[idx(ix + 1, iz + 1)] + 1.41)
+      if iz < DIM - 1:
+        dist[i] = min(dist[i], dist[idx(ix, iz + 1)] + 1.0)
+
+proc fill_grids() =
+  classify()
+  chamfer(LAND, shore)
+  var to_water = new_seq[float32](DIM * DIM)
+  chamfer(WATER, to_water)
+  for ix in 0 ..< DIM:
+    for iz in 0 ..< DIM:
+      let
+        i = idx(ix, iz)
+        x = wxf(ix)
+        z = wzf(iz)
+      case kind_g[i]
+      of NONE:
+        top[i] = 0
+      of WATER:
+        # calm river, full sea swell at the mouth; the river's texture is
+        # painted (river_flow_streak), not sculpted
+        let damp = 0.35 + 0.65 * open_sea[i]
+        wave[i] = wave_height(x, z) * damp
+        top[i] = int16(clamp(int(round(SEA_BASE + wave[i])), 0, 120))
+        # (fill_water recomputes this per animation frame)
+      of LAND:
+        # beaches: meadow flattens toward any water; cliffs and the island
+        # keep their own profiles (slot canyon walls stay vertical)
+        let beach = 0.2 + max(to_water[i] - 1.0, 0.0) * 0.28
+        var e = min(elev[i], beach)
+        if island_elev(x, z) > 0.05:
+          e = elev[i]
+        e = max(e, cliff[i])
+        elev[i] = e
+        top[i] = int16(clamp(int(round(SEA_BASE + e)), 0, 120))
+
+proc fill_water() =
+  ## Recompute the wave field and water tops for the current sea_time; the
+  ## land grids never change between frames.
+  for ix in 0 ..< DIM:
+    for iz in 0 ..< DIM:
+      let i = idx(ix, iz)
+      if kind_g[i] == WATER:
+        let damp = 0.35 + 0.65 * open_sea[i]
+        wave[i] = wave_height(wxf(ix), wzf(iz)) * damp
+        top[i] = int16(clamp(int(round(SEA_BASE + wave[i])), 0, 120))
+
+# --- emission --------------------------------------------------------------------
+
+proc land_surface(ix, iz: int): Color =
+  let
+    i = idx(ix, iz)
+    x = wxf(ix)
+    z = wzf(iz)
+    e = elev[i].float
+    cl = cliff[i].float
+  var slope = 0.0
+  if ix > 0 and ix < DIM - 1:
+    slope = max(slope, abs(elev[idx(ix + 1, iz)] - elev[idx(ix - 1, iz)]).float)
+  if iz > 0 and iz < DIM - 1:
+    slope = max(slope, abs(elev[idx(ix, iz + 1)] - elev[idx(ix, iz - 1)]).float)
+  if cl > 3.0 and cl >= e - 0.01:
+    # cliff: rock strata on the faces, grass wherever it flattens out
+    # (plateau top, terrace ledges, headland tails)
+    if slope < 1.4:
+      let patch = fbm(x / 13.0, z / 13.0, 80, 3)
+      return mix(low_grass, high_grass, clamp(e / CLIFF_H, 0.0, 1.0) * 0.7 + patch * 0.3)
+    let strata = vnoise(e / 6.5, (x + z) / 90.0, 47)
+    return mix(rock_dark, rock_light, clamp(e / CLIFF_H, 0.0, 1.0) * 0.55 + strata * 0.45)
+  if e < 1.0:
+    return mix(wet_sand, dry_sand, e / 1.0)
+  if slope > 1.15 and e > 2.5:
+    return mix(rock, high_grass, 0.15)
+  let
+    patch = fbm(x / 13.0, z / 13.0, 80, 3)
+    alt = clamp((e - 1.0) / 8.0, 0.0, 1.0)
+  result = mix(low_grass, high_grass, alt * 0.5 + patch * 0.5)
+  # deep-green swathes and wildflower flecks keep the prairie lively
+  let shade = fbm(x / 23.0, z / 23.0, 82, 3)
+  if shade > 0.55:
+    result = mix(result, shade_grass, (shade - 0.55) * 2.0)
+  if e > 1.0 and hash01(ix, iz, 23) > 0.9955:
+    result = FLOWERS[int(hash01(ix, iz, 24) * 3.999)]
+
+proc water_surface(ix, iz: int): Color =
+  let
+    i = idx(ix, iz)
+    x = wxf(ix)
+    z = wzf(iz)
+    h = wave[i].float
+    e = -shore[i].float * 0.06 # shore-proximity analog of demo_sea's seabed
+    s = open_sea[i].float
+    # color from the un-damped wave: the calm river keeps the sea's full
+    # crest/trough banding
+    hc = h / (0.35 + 0.65 * s)
+    t = clamp((hc + 1.0) / 2.0, 0.0, 1.0)
+  result =
+    if t < 0.5:
+      mix(deep_water, mid_water, t / 0.5)
+    else:
+      mix(mid_water, crest_water, (t - 0.5) / 0.5)
+  # the river runs deeper blue than the open sea
+  result = mix(result, deep_water, 0.30 * (1.0 - s))
+  # falls-style foam lines and dashes sliding downstream
+  if s < 0.75:
+    let fs = river_flow_streak(x, z)
+    if fs > 0.0:
+      result = mix(result, mix(crest_water, foam, 0.6), fs * 0.65 * (1.0 - s))
+  let shallow = clamp(e + 1.0, 0.0, 1.0)
+  if shallow > 0.0:
+    result = mix(result, shallow_water, shallow * 0.85)
+  # plunge pool: churned white below the falls (the churn field drifts in a
+  # small circle so it animates and still loops)
+  let pool = sqrt((x - FALLS_X - 4.0) ^ 2 + (z - FALLS_Z) ^ 2)
+  if pool < 20.0:
+    var
+      chx = x
+      chz = z
+    if FRAMES > 0:
+      let ph = 2.0 * PI * sea_time / LOOP
+      chx = x + 2.2 * (cos(ph) - 1.0)
+      chz = z + 2.2 * sin(ph)
+    let churn = fbm(chx / 4.2, chz / 4.2, 92, 3)
+    result = mix(result, foam, clamp(1.0 - pool / 20.0, 0.0, 1.0) * (0.4 + 0.6 * churn))
+    # near-solid crash froth where the curtain meets the river
+    if x > -238.0 and x < -229.0 and abs(z - FALLS_Z) < 11.0:
+      result = mix(result, foam, 0.65 + 0.35 * churn)
+  if e > -0.55:
+    result = mix(result, foam, (e + 0.55) / 0.55 * 0.55)
+  if e > -0.18:
+    result = foam
+  else:
+    var grad = 0.0
+    if ix > 0 and ix < DIM - 1:
+      grad += abs(wave[idx(ix + 1, iz)] - wave[idx(ix - 1, iz)]).float
+    if iz > 0 and iz < DIM - 1:
+      grad += abs(wave[idx(ix, iz + 1)] - wave[idx(ix, iz - 1)]).float
+    grad = grad / 2.0
+    let breaking = open_sea[i] > 0.5
+    if breaking and h > 0.32 and grad > 0.55 and fbm(x / 3.7, z / 3.7, 90, 3) > 0.52:
+      result = mix(result, foam, 0.9)
+    elif hash01(ix, iz, 11) > 0.9975 and h > 0.0:
+      result = foam
+
+# --- trees (shapes borrowed from world1's SpiralTree/OrbTree/CoralTree) ---------
+
+proc stamp_ball(build: Build, ox, oz, cx, cy, cz, r: float, c: Color): int =
+  let ir = int(ceil(r))
+  for dx in -ir .. ir:
+    for dy in -ir .. ir:
+      for dz in -ir .. ir:
+        if float(dx * dx + dy * dy + dz * dz) <= r * r + 0.4:
+          build.draw(
+            vec3(cx + dx.float - ox, cy + dy.float, cz + dz.float - oz), (KIND, c)
+          )
+          result.inc
+
+proc stamp_disc(build: Build, ox, oz, cx, y, cz, r: float, c: Color): int =
+  let ir = int(ceil(r))
+  for dx in -ir .. ir:
+    for dz in -ir .. ir:
+      if float(dx * dx + dz * dz) <= r * r + 0.3:
+        build.draw(vec3(cx + dx.float - ox, y, cz + dz.float - oz), (KIND, c))
+        result.inc
+
+proc tree_palm(
+    build: Build, ox, oz, x, base, z: float, h: int, r1, r2: float, fcol: Color
+): int =
+  ## Palm with a gentle trunk curve, a frond crown that spreads with height,
+  ## and the odd coconut.
+  let
+    lean_x = (r1 - 0.5) * 4.0
+    lean_z = (r2 - 0.5) * 4.0
+  var
+    tx = x
+    tz = z
+  for i in 0 ..< h:
+    let t = i.float / h.float
+    tx = x + lean_x * t * t
+    tz = z + lean_z * t * t
+    build.draw(vec3(round(tx) - ox, base + i.float, round(tz) - oz), (KIND, trunk_col))
+    result.inc
+  let
+    ty = base + h.float
+    arms = 4 + int(r1 * 3.0)
+    reach = 2 + int(h.float * 0.18 + r2 * 2.0) # taller palms spread wider
+  build.draw(vec3(round(tx) - ox, ty + 1.0, round(tz) - oz), (KIND, fcol))
+  result.inc
+  for a in 0 ..< arms:
+    let ang = a.float * (2.0 * PI / arms.float) + r2 * 0.8
+    for s in 1 .. reach:
+      let droop =
+        if s <= reach div 2:
+          0.0
+        else:
+          round(float(s - reach div 2) * 0.7)
+      build.draw(
+        vec3(
+          round(tx + cos(ang) * s.float) - ox, ty - droop,
+          round(tz + sin(ang) * s.float) - oz,
+        ),
+        (KIND, fcol),
+      )
+      result.inc
+  if h >= 9 and r1 > 0.4: # coconuts
+    build.draw(vec3(round(tx) + 1.0 - ox, ty - 1.0, round(tz) - oz), (KIND, trunk_col))
+    build.draw(vec3(round(tx) - ox, ty - 1.0, round(tz) - 1.0 - oz), (KIND, trunk_col))
+    result += 2
+
+proc tree_broadleaf(
+    build: Build, ox, oz, x, base, z: float, h: int, r1, r2, r3: float,
+    tcol, lcol: Color,
+): int =
+  ## Straight trunk with a lumpy layered canopy.
+  for i in 0 ..< h:
+    result += stamp_disc(
+      build, ox, oz, x, base + i.float, z, (if i < 2: 1.5 else: 0.9), tcol
+    )
+  let cr = 2.8 + h.float * 0.18 + r1 * 1.2
+  result += stamp_ball(build, ox, oz, x, base + h.float + cr * 0.4, z, cr, lcol)
+  result += stamp_ball(
+    build, ox, oz, x + (r2 - 0.5) * 4.0, base + h.float, z + (r3 - 0.5) * 4.0,
+    cr * 0.6, lcol,
+  )
+  result += stamp_ball(
+    build, ox, oz, x - (r3 - 0.5) * 3.0, base + h.float + 1.0, z - (r2 - 0.5) * 3.0,
+    cr * 0.5, lcol,
+  )
+
+proc tree_conifer(
+    build: Build, ox, oz, x, base, z: float, h: int, r1: float, tcol: Color
+): int =
+  ## Tapered cone on a short trunk.
+  for i in 0 ..< 2:
+    build.draw(vec3(x - ox, base + i.float, z - oz), (KIND, tcol))
+    result.inc
+  let spread = 0.8 + r1 * 0.4
+  for i in 0 ..< h:
+    let r = max(0.6, float(h - i) * 0.32 * spread)
+    result += stamp_disc(build, ox, oz, x, base + 2.0 + i.float, z, r, conifer_green)
+  build.draw(vec3(x - ox, base + 2.0 + h.float, z - oz), (KIND, conifer_green))
+  result.inc
+
+proc low_neighbor(ix, iz: int): int =
+  result = top[idx(ix, iz)].int
+  for dx in -1 .. 1:
+    for dz in -1 .. 1:
+      let
+        nx = ix + dx
+        nz = iz + dz
+      if nx >= 0 and nx < DIM and nz >= 0 and nz < DIM:
+        result = min(result, top[idx(nx, nz)].int)
+
+proc emit_land(build: Build, ix0, ix1: int): int =
+  let
+    ox = build.start_transform.origin.x
+    oz = build.start_transform.origin.z
+  build.buffer:
+    for ix in ix0 ..< ix1:
+      for iz in 0 ..< DIM:
+        let i = idx(ix, iz)
+        if kind_g[i] != LAND:
+          continue
+        let
+          x = wxf(ix)
+          z = wzf(iz)
+          hi = top[i].int
+          cl = cliff[i].float
+        var lo = low_neighbor(ix, iz)
+        if abs(x - ox) <= 2 and abs(z - oz) <= 2:
+          lo = 0 # keep the unit's origin block buried
+        if cl > 3.0:
+          lo = 0 # cliffs are solid rock, not a hollow crust
+        let surface = land_surface(ix, iz)
+        for y in lo .. hi:
+          let c =
+            if y == hi:
+              surface
+            elif cl > 3.0:
+              mix(rock_dark, rock_mid, vnoise(y.float / 5.0, (x - z) / 70.0, 48))
+            else:
+              mix(wet_sand, rock, 0.5)
+          build.draw(vec3(x - ox, y.float, z - oz), (KIND, c))
+          result.inc
+        # dense small palms along the coasts and on the island
+        let
+          e = elev[i].float
+          is_island = island_elev(x, z) > 0.05
+          palm_bar = if is_island: 0.9968 else: 0.9987
+          falls_clear = not (x < -200.0 and abs(z - FALLS_Z) < 20.0)
+          # fronds must never reach the falls wedge — it's the one tall
+          # water, and a shared position across two Things z-fights
+        if cl < 3.0 and e > 1.0 and (is_island or e < 2.4) and falls_clear and
+            hash01(ix, iz, 20) > palm_bar:
+          result += tree_palm(
+            build, ox, oz, x, float(hi + 1), z, 5 + int(hash01(ix, iz, 21) * 6.0),
+            hash01(ix, iz, 22), hash01(ix, iz, 25),
+            PALM_GREENS[int(hash01(ix, iz, 26) * 2.999)],
+          )
+        # inland trees on a jittered grid: one candidate spot per cell, so
+        # they spread evenly without crowding. Mostly palms, with the odd
+        # broadleaf or conifer for variety.
+        const TCELL = 18
+        let
+          cx = ix div TCELL
+          cz = iz div TCELL
+          spot_x = cx * TCELL + int(hash01(cx, cz, 30) * (TCELL - 4).float) + 2
+          spot_z = cz * TCELL + int(hash01(cx, cz, 31) * (TCELL - 4).float) + 2
+        if ix == spot_x and iz == spot_z and cl < 3.0 and e > 1.0 and
+            hash01(cx, cz, 32) < 0.22 and falls_clear and
+            cliff_elev(x + 7.0, z) < 6.0 and cliff_elev(x - 7.0, z) < 6.0 and
+            cliff_elev(x, z + 7.0) < 6.0 and cliff_elev(x, z - 7.0) < 6.0:
+          let
+            r1 = hash01(cx, cz, 33)
+            r2 = hash01(cx, cz, 34)
+            r3 = hash01(cx, cz, 35)
+            kind_pick = hash01(cx, cz, 36)
+            base = float(hi + 1)
+          if kind_pick < 0.72:
+            let h = 6 + int(r1 * 10.0) # 6..16
+            result += tree_palm(
+              build, ox, oz, x, base, z, h, r1, r2,
+              PALM_GREENS[int(r3 * 2.999)],
+            )
+          elif kind_pick < 0.9:
+            let h = 5 + int(r2 * 7.0) # 5..12
+            result += tree_broadleaf(
+              build, ox, oz, x, base, z, h, r1, r2, r3,
+              TRUNKS[int(hash01(cx, cz, 37) * 1.999)], # brown or charcoal
+              LEAF_GREENS[int(r1 * 2.999)],
+            )
+          else:
+            let h = 8 + int(r3 * 10.0) # 8..18
+            result += tree_conifer(build, ox, oz, x, base, z, h, r1, trunk_col)
+
+proc emit_water(build: Build, ix0, ix1: int): int =
+  let
+    ox = build.start_transform.origin.x
+    oz = build.start_transform.origin.z
+  build.buffer:
+    for ix in ix0 ..< ix1:
+      for iz in 0 ..< DIM:
+        let i = idx(ix, iz)
+        if kind_g[i] != WATER:
+          continue
+        let
+          x = wxf(ix)
+          z = wzf(iz)
+          hi = top[i].int
+          lo = min(low_neighbor(ix, iz), 0) # always seal to the plane
+          surface = water_surface(ix, iz)
+        for y in lo .. hi:
+          let c =
+            if y == hi:
+              surface
+            elif y == hi - 1:
+              mid_water
+            else:
+              deep_water
+          build.draw(vec3(x - ox, y.float, z - oz), (KIND, c))
+          result.inc
+        # churning froth mounds at the curtain's base — raised foam voxels
+        # that boil with the (looping) churn drift
+        if x > -237.0 and x < -230.0 and abs(z - FALLS_Z) < 10.0:
+          var
+            fx = x
+            fz = z
+          if FRAMES > 0:
+            let ph = 2.0 * PI * sea_time / LOOP
+            fx = x + 2.2 * (cos(ph) - 1.0)
+            fz = z + 2.2 * sin(ph)
+          if fbm(fx / 3.1, fz / 3.1, 93, 3) > 0.5:
+            build.draw(vec3(x - ox, float(hi + 1), z - oz), (KIND, foam))
+            result.inc
+        # waterfall on the west cliff at the river head: a solid streaked
+        # wedge filling the notch from the curtain face back to the rock and
+        # up to the (undulating) lip, so no angle can see behind it
+        if x > FALLS_X - 7.5 and x <= FALLS_X - 6.5 and abs(z - FALLS_Z) < 10.0:
+          var
+            back = 0
+            wall_top = 0
+          for step in 1 .. 20:
+            let nx = ix - step
+            if nx < 0:
+              break
+            if kind_g[idx(nx, iz)] == LAND and top[idx(nx, iz)] > 25:
+              back = step
+              wall_top = top[idx(nx, iz)].int
+              break
+          if wall_top > 0:
+            for bx in 0 ..< back:
+              let bi = idx(ix - bx, iz)
+              if kind_g[bi] != WATER:
+                continue
+              # rounded shoulder: the front of the lip arcs over instead of
+              # ending in a square corner
+              let ctop = wall_top - (if bx == 0: 2 elif bx == 1: 1 else: 0)
+              for y in top[bi].int + 1 .. ctop:
+                let streak = falls_streak(z, y.float, bx.float * 0.4)
+                let c = mix(crest_water, foam, 0.2 + 0.7 * streak)
+                build.draw(vec3(x - bx.float - ox, y.float, z - oz), (KIND, c))
+                result.inc
+            # chunky spray: heavy streaks bulge a voxel out of the face, so
+            # the curtain has animated relief instead of a flat plane
+            let front = idx(ix + 1, iz)
+            if kind_g[front] == WATER:
+              for y in top[front].int + 3 .. wall_top - 4:
+                if falls_streak(z, y.float, -0.4) > 0.62:
+                  build.draw(
+                    vec3(x + 1.0 - ox, y.float, z - oz),
+                    (KIND, mix(crest_water, foam, 0.8)),
+                  )
+                  result.inc
+
+# --- main ------------------------------------------------------------------------
+
+echo "connecting", (if ADDR == "": "" else: " to " & ADDR), "..."
+Enu.connect(ADDR)
+# terrain and water are adjacent at every shoreline; without this, draw's
+# hand-placement join logic tries to merge them (and dereferences the game
+# state a plain client doesn't have)
+dont_join = true
+
+echo "filling ", DIM, "x", DIM, " grids..."
+fill_grids()
+
+proc new_build(id: string, x, z: float, cull_down: bool): Build =
+  result =
+    if SAVE:
+      Build.init(id = id, transform = Transform.init(vec3(x, 0.0, z)))
+    else:
+      Build.init(id = id & "_" & generate_id(), transform = Transform.init(vec3(x, 0.0, z)))
+  if not SAVE:
+    result.global_flags += EPHEMERAL
+  result.end_asap()
+  result.voxels.immediate = true
+  Enu.things.add result
+  result.cull_down_faces = cull_down
+  Enu.client.tick
+
+let
+  # nobody culls down faces anymore: tree canopies and the falls' spray
+  # bulges are both seen from below — and cull_down_faces isn't persisted,
+  # so the shipped level never had the water cull anyway. If the frame-mesh
+  # cache ever needs the savings back, the answer is the y==0-only engine
+  # cull, not this flag.
+  terrain = new_build("build_terrain", 0.0, 100.0, cull_down = false)
+  water = new_build("build_water", 0.0, -400.0, cull_down = false)
+
+var
+  land_total = 0
+  water_total = 0
+const BAND = 50
+for bx in countup(0, DIM - 1, BAND):
+  let hi = min(bx + BAND, DIM)
+  land_total += emit_land(terrain, bx, hi)
+  water_total += emit_water(water, bx, hi)
+  echo "band ", bx, "/", DIM, "  land=", land_total, " water=", water_total
+  discard Enu.client.tick_until(PACE.seconds, false)
+
+echo "TERRAIN=", terrain.id, " voxels=", land_total
+echo "WATER=", water.id, " voxels=", water_total
+
+if FRAMES > 0:
+  # the static pass above IS frame 0 (sea_time = 0); redraw the water for
+  # each later frame from a clean voxel state, demo_sea-style
+  echo "generating ", FRAMES, " water frames over ", LOOP, "s..."
+  for f in 0 ..< FRAMES:
+    sea_time = LOOP * f.float / FRAMES.float
+    if f > 0:
+      water.voxels.clear(all = true)
+      fill_water()
+      var n = 0
+      for bx in countup(0, DIM - 1, BAND):
+        n += emit_water(water, bx, min(bx + BAND, DIM))
+        discard Enu.client.tick_until(PACE.seconds, false)
+    let index = water.save()
+    echo "frame ", index, " saved"
+    discard Enu.client.tick_until(FRAME_PACE.seconds, false)
+  echo "settling..."
+  discard Enu.client.tick_until(5.seconds, false)
+  let fps = FRAMES.float / LOOP
+  if SAVE:
+    # persist playback as the unit's script (reload does not auto-play)
+    water.code = Code.init("play(" & $fps & ")\n", runner = Enu.server_ctx_id)
+    echo "water saved with a play(", fps, ") script — reload animates it"
+  else:
+    water.play(fps = fps)
+    echo "water playing at ", fps, " fps"
+
+if SAVE:
+  echo "saving with the level — exit once fully visible in Enu"
+else:
+  echo "terrain is up — keeping it alive (kill me to reap it)"
+Enu.client.every(1.second):
+  discard

--- a/src/controllers/script_controllers/worker.nim
+++ b/src/controllers/script_controllers/worker.nim
@@ -824,7 +824,8 @@ proc worker_thread(params: (EdContext, GameState)) {.gcsafe.} =
           # Flush if not in ASAP mode, or if in ASAP mode and we can flush
           let should_flush = not in_asap or can_flush_asap
           if should_flush:
-            if build.voxels.pending_chunks.len > 0:
+            if build.voxels.pending_chunks.len > 0 or
+                build.voxels.pending_snapshots.len > 0:
               # Flush chunk-by-chunk, backing off once the channel hits the gate
               # (the rest stay in pending_chunks and coalesce next frame).
               for _ in build.voxels.flush_dirty_chunks():

--- a/src/controllers/script_controllers/worker.nim
+++ b/src/controllers/script_controllers/worker.nim
@@ -330,7 +330,10 @@ proc watch_code(self: Worker, thing: Thing) =
   thing.code_value.changes:
     if added or touched:
       if change.item.runner == Ed.thread_ctx.id:
-        save_level(state.config.level_dir)
+        if not level_loading:
+          # the loader assigns every unit's code; saving the level it is
+          # mid-loading re-encoded everything back to disk for nothing
+          save_level(state.config.level_dir)
         self.change_code(thing, change.item)
         if change.item.nim == "":
           remove_file thing.script_ctx.script

--- a/src/game.nim
+++ b/src/game.nim
@@ -21,6 +21,7 @@ var next_perf_log {.threadvar.}: MonoTime
 var next_voxmem_log {.threadvar.}: MonoTime
 var last_frame_at {.threadvar.}: MonoTime
 var slow_frame_log {.threadvar.}: int ## 0 unread, 1 on, -1 off
+var slow_frame_ms {.threadvar.}: float ## threshold; ENU_SLOW_FRAME_MS
 
 # Immediate process exit that runs no atexit handlers, C++ destructors, or Nim
 # GC teardown. Used to end test-mode runs without triggering Godot's headless
@@ -107,10 +108,17 @@ gdobj Game of Node:
     # 2s PERF sampling undercounts short hitches. One clock compare per frame.
     if slow_frame_log == 0:
       slow_frame_log = if get_env("ENU_PERF_LOG") != "": 1 else: -1
+      slow_frame_ms = 100.0
+      try:
+        let t = get_env("ENU_SLOW_FRAME_MS")
+        if t != "":
+          slow_frame_ms = t.parse_float
+      except ValueError:
+        discard
     if slow_frame_log == 1:
       if last_frame_at != MonoTime():
         let gap = (time - last_frame_at).in_milliseconds.float
-        if gap > 100.0:
+        if gap > slow_frame_ms:
           info "SLOW_FRAME", ms = gap
       last_frame_at = time
 

--- a/src/game.nim
+++ b/src/game.nim
@@ -129,13 +129,18 @@ gdobj Game of Node:
     # tick, never per frame.
     if time > next_perf_log and get_env("ENU_PERF_LOG") != "":
       next_perf_log = time + 2.seconds
+      let vtasks = get_stats()["tasks"].as_dictionary
       info "PERF",
         fps = get_monitor(TIME_FPS),
         frame_ms = get_monitor(TIME_PROCESS) * 1000.0,
         vertex_mem_kb = (get_monitor(RENDER_VERTEX_MEM_USED) / 1024.0).int,
         objects = get_monitor(RENDER_OBJECTS_IN_FRAME).int,
         draw_calls = get_monitor(RENDER_DRAW_CALLS_IN_FRAME).int,
-        video_mem_mb = (get_monitor(RENDER_VIDEO_MEM_USED) / 1048576.0).int
+        video_mem_mb = (get_monitor(RENDER_VIDEO_MEM_USED) / 1048576.0).int,
+        # VoxelServer in-flight task gauges (live counts, not cumulative —
+        # for totals, sum the per-terrain TERRAIN `meshed` counter instead).
+        mesh_queue = parse_int($vtasks["meshing"]),
+        gen_queue = parse_int($vtasks["generation"])
 
     # Opt-in resident voxel memory sampling (ENU_VOXEL_MEM_LOG=1): thread-heap
     # occupancy + per-store counters, for before/after comparisons of the

--- a/src/game.nim
+++ b/src/game.nim
@@ -19,6 +19,8 @@ import libs/fd_tracking
 
 var next_perf_log {.threadvar.}: MonoTime
 var next_voxmem_log {.threadvar.}: MonoTime
+var last_frame_at {.threadvar.}: MonoTime
+var slow_frame_log {.threadvar.}: int ## 0 unread, 1 on, -1 off
 
 # Immediate process exit that runs no atexit handlers, C++ destructors, or Nim
 # GC teardown. Used to end test-mode runs without triggering Godot's headless
@@ -99,6 +101,18 @@ gdobj Game of Node:
       if self.update_metrics_at < time:
         update_thread_metrics()
         self.update_metrics_at = time + 10.seconds
+
+    # Opt-in hitch log (same env as PERF): every frame gap over 100 ms is a
+    # stutter the player felt — log each one with its true length, since the
+    # 2s PERF sampling undercounts short hitches. One clock compare per frame.
+    if slow_frame_log == 0:
+      slow_frame_log = if get_env("ENU_PERF_LOG") != "": 1 else: -1
+    if slow_frame_log == 1:
+      if last_frame_at != MonoTime():
+        let gap = (time - last_frame_at).in_milliseconds.float
+        if gap > 100.0:
+          info "SLOW_FRAME", ms = gap
+      last_frame_at = time
 
     # Opt-in perf sampling (ENU_PERF_LOG=1): one "PERF" line every ~2s with
     # render-side metrics for before/after comparisons (e.g. greedy meshing).

--- a/src/models/builds.nim
+++ b/src/models/builds.nim
@@ -285,6 +285,8 @@ proc del_voxel(self: Build, position: Vector3) =
   self.voxels.del_voxel(position)
 
 proc restore_edits*(self: Build) =
+  if self.voxels.adopt_edit_chunks():
+    return
   self.voxels.for_all_edits:
     assert info.kind in {PERSISTED, HOLE}
     if info.kind != HOLE:

--- a/src/models/builds.nim
+++ b/src/models/builds.nim
@@ -217,6 +217,7 @@ proc save*(self: Build, at: int = -1): int {.discardable.} =
   ## `load_frame(3)`, edit, `save(at = 3)`). Keyed table writes make
   ## both cases a single synced op.
   self.global_flags += DIRTY
+  self.frames_dirty = true
   if at >= 0 and at < self.frames.len:
     self.frames[at] = self.voxels.pack_frame
     at
@@ -245,6 +246,7 @@ proc clear_frames*(self: Build) =
   ## Scripts that build an animation programmatically call this first;
   ## otherwise save keeps appending across script re-runs.
   self.global_flags += DIRTY
+  self.frames_dirty = true
   self.frames_fps = 0.0
   self.current_frame = -1
   self.frames.clear
@@ -253,6 +255,7 @@ proc delete_frame*(self: Build, index: int) =
   ## Remove a saved frame; later frames shift down one index (keys stay
   ## dense: each higher frame rewrites down by one keyed op).
   self.global_flags += DIRTY
+  self.frames_dirty = true
   if index >= 0 and index < self.frames.len:
     let last = self.frames.len - 1
     for i in index ..< last:

--- a/src/models/serializers.nim
+++ b/src/models/serializers.nim
@@ -149,6 +149,7 @@ proc from_json_hook(self: var Build, json: JsonNode) =
           unit = self.id, frame = i, error = e.msg
         break
     self.reset_bounds() # frame chunks count toward bounds (see reset_bounds)
+    self.frames_dirty = false # loaded verbatim from disk; nothing to re-save
     info "frames sidecar loaded",
       unit = self.id,
       loaded = loaded,
@@ -246,6 +247,11 @@ proc edits_to_string(shared: Shared): string =
         \"\"{thing_id}\": [\n{elements}\n]"
   result = edits.join(",\n")
 
+proc count_frame_files(dir: string): int =
+  for kind, path in walk_dir(dir):
+    if kind == pcFile and path.ends_with(".bin"):
+      inc result
+
 proc save_frames(self: Build) =
   ## Frame animation sidecar: data/<id>/frames/NNN.bin, keyframes every
   ## FRAME_KEYFRAME_INTERVAL frames and per-chunk deltas between. The unit
@@ -255,6 +261,14 @@ proc save_frames(self: Build) =
   if self.frames.len == 0:
     if dir_exists(dir):
       remove_dir(dir)
+    return
+  if not self.frames_dirty and dir_exists(dir) and
+      count_frame_files(dir) == self.frames.len:
+    # Untouched since load/last save: skip 24 frame re-encodes per save.
+    # (Local frame mutations set frames_dirty; client-synced frames are
+    # covered by the dir/count checks — a same-count in-place replacement
+    # from a remote client is the one uncovered case, and the generator
+    # workflow always starts from a deleted data dir.)
     return
   create_dir dir
   var prev = none(FrameData)
@@ -278,6 +292,7 @@ proc save_frames(self: Build) =
         discard
       if stale:
         remove_file path
+  self.frames_dirty = false
 
 proc extras_json(self: Thing): string =
   ## Optional trailing sections for the unit JSON: frame-animation metadata
@@ -748,7 +763,16 @@ proc unload_level*(worker: Worker) =
   state.pop_flag LOADING_SCRIPT
   state.global_flags -= LOADING_LEVEL
 
+var level_loading* = false
+  ## True while load_level populates things. watch_code's autosave consults
+  ## this: the loader assigning each unit's code was triggering a full
+  ## save_level (frame re-encodes included) synchronously inside the load —
+  ## most of a debug build's 5-10s boot penalty.
+
 proc load_level*(worker: Worker, level_dir: string) =
+  level_loading = true
+  defer:
+    level_loading = false
   state.global_flags += LOADING_LEVEL
   state.push_flag LOADING_SCRIPT
   if not state.player.is_nil:

--- a/src/models/voxels/codec.nim
+++ b/src/models/voxels/codec.nim
@@ -408,6 +408,15 @@ proc is_empty*(packed: PackedChunk): bool =
   packed.data.len == 0 or
     (packed.data.len == 1 and packed.data[0].byte == FMT_EMPTY.byte)
 
+proc voxel_count*(packed: PackedChunk): int =
+  ## Non-empty cells in an encoded chunk — what painting this content
+  ## would report as painted (see render_snapshot_direct).
+  if packed.is_empty:
+    return 0
+  for voxel in decode_chunk(packed):
+    if voxel != EMPTY_VOXEL:
+      inc result
+
 proc encode_delta*(
     changes: openArray[tuple[pos: Vector3, voxel: PackedVoxel]]
 ): DeltaUpdate =

--- a/src/models/voxels/store.nim
+++ b/src/models/voxels/store.nim
@@ -314,6 +314,82 @@ proc flush_edits_for_save*(self: VoxelStore) =
   for chunk_id in self.local_edits.keys:
     self.flush_edit_snapshot(chunk_id)
 
+proc adopt_chunk(
+    self: VoxelStore, chunk_id: Vector3,
+    cells: array[CHUNK_VOLUME, PackedVoxel], snapshot: SnapshotData,
+    changed: bool,
+) =
+  ## Install one bulk-restored chunk: cells into the read cache, and the
+  ## packed form into the synced table (the stored blob verbatim when the
+  ## cells match it exactly).
+  let chunk = CachedChunk()
+  var dropped = changed
+  for linear in 0 ..< CHUNK_VOLUME:
+    let v = cells[linear]
+    if v == EMPTY_VOXEL:
+      continue
+    let (_, kind_ord) = unpack_voxel(v)
+    if VoxelKind(kind_ord) == HOLE:
+      dropped = true # erases nothing with no base; excluded from live state
+      continue
+    chunk.cells[linear] = v
+    inc chunk.count
+  if chunk.count == 0:
+    return
+  if not self.on_chunk_created.is_nil:
+    self.on_chunk_created(chunk_id)
+  inc self.cache_tick
+  chunk.tick = self.cache_tick
+  self.chunk_cache[chunk_id] = chunk
+  if dropped:
+    self.flush_chunk_snapshot(chunk_id)
+  else:
+    self.packed_chunks[chunk_id] = snapshot
+
+proc adopt_edit_chunks*(self: VoxelStore): bool =
+  ## Bulk restore for a store with no live content — the fresh-load path of a
+  ## persisted build, where the edits ARE the content. Each edit chunk's
+  ## packed cells are adopted directly as the live chunk and published as one
+  ## snapshot, instead of round-tripping every voxel through
+  ## unpack/resolve_color -> add_voxel/pack_color_index (seconds per million
+  ## voxels at load, plus a redundant set_edit per voxel). HOLE edits erase
+  ## from a base; with no base they are no-ops and are skipped. Returns false
+  ## when live content already exists (script rerun/reset) — the caller keeps
+  ## the per-voxel overlay semantics.
+  if self.chunk_cache.len > 0 or self.pending_chunks.len > 0:
+    return false
+  var handled = init_hash_set[Vector3]()
+  if ?self.edit_snapshots:
+    for key, snapshot in self.edit_snapshots:
+      if key.id != self.thing_id:
+        continue
+      let chunk_id = key.loc
+      var cells = decode_chunk(snapshot)
+      var changed = false
+      if ?self.edit_deltas and key in self.edit_deltas:
+        let delta_seq = self.edit_deltas[key]
+        if ?delta_seq:
+          for delta in delta_seq:
+            for (local_pos, packed_voxel) in decode_delta(delta):
+              cells[
+                linear_position(local_pos.x.int, local_pos.y.int, local_pos.z.int)
+              ] = packed_voxel
+              changed = true
+      handled.incl chunk_id
+      self.adopt_chunk(chunk_id, cells, snapshot, changed)
+  if ?self.edit_deltas:
+    for key, delta_seq in self.edit_deltas:
+      if key.id != self.thing_id or key.loc in handled or not ?delta_seq:
+        continue
+      var cells: array[CHUNK_VOLUME, PackedVoxel]
+      for delta in delta_seq:
+        for (local_pos, packed_voxel) in decode_delta(delta):
+          cells[
+            linear_position(local_pos.x.int, local_pos.y.int, local_pos.z.int)
+          ] = packed_voxel
+      self.adopt_chunk(key.loc, cells, SnapshotData(), changed = true)
+  true
+
 proc add_voxel*(self: VoxelStore, position: Vector3, voxel: VoxelInfo) =
   let chunk_id = position.buffer
   let chunk = self.cached_chunk(chunk_id)

--- a/src/models/voxels/store.nim
+++ b/src/models/voxels/store.nim
@@ -85,7 +85,8 @@ proc cached_chunk(self: VoxelStore, chunk_id: Vector3): CachedChunk =
     var oldest_id: Vector3
     var oldest_tick = int.high
     for id, entry in self.chunk_cache:
-      if entry.tick < oldest_tick and id notin self.pending_chunks:
+      if entry.tick < oldest_tick and id notin self.pending_chunks and
+          id notin self.pending_snapshots:
         oldest_tick = entry.tick
         oldest_id = id
     if oldest_tick < int.high:
@@ -238,6 +239,17 @@ iterator flush_dirty_chunks*(self: VoxelStore): Vector3 =
       self.flush_chunk_delta(chunk_id, changes)
     self.pending_chunks.del chunk_id
     yield chunk_id
+  for chunk_id in self.pending_snapshots.keys.to_seq:
+    let blob = self.pending_snapshots[chunk_id]
+    if blob.data.len > 0:
+      self.packed_chunks[chunk_id] = blob # bulk-adopted, publish verbatim
+      if chunk_id in self.chunk_deltas:
+        self.chunk_deltas[chunk_id].clear
+      inc self.snapshots_flushed
+    else:
+      self.flush_chunk_snapshot(chunk_id)
+    self.pending_snapshots.del chunk_id
+    yield chunk_id
 
 proc flush_dirty_chunks*(self: VoxelStore) =
   ## Flush every dirty chunk (save / end_asap). The worker uses the iterator form
@@ -341,10 +353,14 @@ proc adopt_chunk(
   inc self.cache_tick
   chunk.tick = self.cache_tick
   self.chunk_cache[chunk_id] = chunk
-  if dropped:
-    self.flush_chunk_snapshot(chunk_id)
-  else:
-    self.packed_chunks[chunk_id] = snapshot
+  # Stage for the paced flusher rather than publishing here: load adopts
+  # thousands of chunks, and pushing them all through sync in one burst
+  # overwhelms the channel right when boot is busiest.
+  self.pending_snapshots[chunk_id] =
+    if dropped:
+      SnapshotData()
+    else:
+      snapshot
 
 proc adopt_edit_chunks*(self: VoxelStore): bool =
   ## Bulk restore for a store with no live content — the fresh-load path of a
@@ -356,7 +372,8 @@ proc adopt_edit_chunks*(self: VoxelStore): bool =
   ## from a base; with no base they are no-ops and are skipped. Returns false
   ## when live content already exists (script rerun/reset) — the caller keeps
   ## the per-voxel overlay semantics.
-  if self.chunk_cache.len > 0 or self.pending_chunks.len > 0:
+  if self.chunk_cache.len > 0 or self.pending_chunks.len > 0 or
+      self.pending_snapshots.len > 0:
     return false
   var handled = init_hash_set[Vector3]()
   if ?self.edit_snapshots:

--- a/src/nodes/build_node.nim
+++ b/src/nodes/build_node.nim
@@ -560,8 +560,15 @@ gdobj BuildNode of VoxelTerrain:
     # named indices pass through untouched (identity below STATIC_COLOR_BASE).
     set_registry_library(self.mesher.as(VoxelMesherBlocky).library)
     let model = self.model
+    # Memoized: palette indices never re-map (the palette is append-only),
+    # and slot_for hashes a Color per call — far too hot for per-voxel
+    # resolution in the frame drain (profiled at ~13% of main during paging).
+    var slot_memo = init_table[int, int64]()
     self.resolver = proc(color_index: int): int64 =
-      slot_for(resolve_color(model.shared, color_index))
+      slot_memo.with_value(color_index, memoized):
+        return memoized[]
+      result = slot_for(resolve_color(model.shared, color_index))
+      slot_memo[color_index] = result
 
     # Pre-register the build's whole palette (it syncs with the unit and
     # lists every static color the build will ever render), so a block

--- a/src/nodes/build_node.nim
+++ b/src/nodes/build_node.nim
@@ -278,9 +278,8 @@ gdobj BuildNode of VoxelTerrain:
           self.watch_delta_seq(chunk_id, delta_seq)
       flush_registry()
       if displaying_frame:
-        # give the fresh chunk its frame content (cheap for the rest:
-        # display-key checks make the loop a no-op elsewhere)
-        self.frames.show(self.model.current_frame)
+        # give the fresh chunk its frame content on the next drain
+        self.frames.show_chunk(chunk_id, self.model.current_frame)
       let took = (get_mono_time() - start).in_milliseconds
       if took > 10:
         warn "on_block_loaded slow", ms = took, unit = self.model.id

--- a/src/nodes/build_node.nim
+++ b/src/nodes/build_node.nim
@@ -1,4 +1,4 @@
-import std/[tables, bitops, times, options, sets, hashes]
+import std/[tables, bitops, times, options, sets, hashes, os]
 import pkg/godot except print, Color
 import
   godotapi/[
@@ -27,6 +27,10 @@ template each_material(self, i, m, body: untyped) =
     if not ?m:
       break
     body
+
+let prefill_disabled = get_env("ENU_NO_PREFILL") == "1"
+  ## A/B switch: disable the enu_chunk_bytes prefill so paged-in blocks take
+  ## the old paint-after-load path (perf comparison).
 
 var build_scene {.threadvar.}: PackedScene
 var shader {.threadvar.}: Shader
@@ -185,8 +189,9 @@ gdobj BuildNode of VoxelTerrain:
     ## block's packed bytes so it's prefilled with real data and meshes once. An
     ## empty result means "not resident" — the engine falls back to an empty
     ## block and today's paint-after-load path carries it.
+    ## ENU_NO_PREFILL=1 disables the hook for prefill-vs-paint A/B measurement.
     result = new_pool_byte_array()
-    if not ?self.model or SERVER in state.local_flags:
+    if not ?self.model or SERVER in state.local_flags or prefill_disabled:
       return
     let bytes = self.model.voxels.prefill_bytes(block_position)
     if bytes.len > 0:

--- a/src/nodes/build_node.nim
+++ b/src/nodes/build_node.nim
@@ -31,11 +31,7 @@ template each_material(self, i, m, body: untyped) =
 let prefill_disabled = get_env("ENU_NO_PREFILL") == "1"
   ## A/B switch: disable the enu_chunk_bytes prefill so paged-in blocks take
   ## the old paint-after-load path (perf comparison).
-let server_prefill = get_env("ENU_SERVER_PREFILL") == "1"
-  ## Experiment: let the SERVER (and therefore solo play) prefill paged-in
-  ## blocks too. Prefill shipped client-only; solo sessions still decode and
-  ## paint every chunk per voxel on main at page-in. Structurally the hook is
-  ## side-agnostic — flip this on to measure before changing the default.
+let perf_log = get_env("ENU_PERF_LOG") != ""
 
 var build_scene {.threadvar.}: PackedScene
 var shader {.threadvar.}: Shader
@@ -64,12 +60,15 @@ gdobj BuildNode of VoxelTerrain:
     default_view_distance: int
     toggle_error_highlight_at = MonoTime.high
     error_highlight_on: bool
+    next_stats_log: MonoTime
+    prefill_hits, prefill_misses: int
     loaded_chunks: HashSet[Vector3]
-    prefilled_chunks: HashSet[Vector3]
+    prefilled_chunks: Table[Vector3, int]
       ## Chunks the request-time hook (enu_chunk_bytes) answered with real bytes,
-      ## so the streaming thread prefilled the engine block with them. Consumed by
-      ## on_block_loaded to skip the now-redundant snapshot + delta paints. See
-      ## docs/notes/voxel-stream-loading.md.
+      ## so the streaming thread prefilled the engine block with them, mapped to
+      ## the served content's voxel count. Consumed by on_block_loaded to skip
+      ## the now-redundant snapshot + delta paints while still crediting
+      ## rendered_voxel_count. See docs/notes/voxel-stream-loading.md.
     tracked_delta_seqs: Table[Vector3, EID]
     renderer: VoxelRenderer
     paging_logged: bool
@@ -129,7 +128,7 @@ gdobj BuildNode of VoxelTerrain:
           # Delta appended while the chunk is still paging in: the prefilled
           # buffer was composed at request time and predates it, so drop the hint
           # and let on_block_loaded repaint the fresh state instead of skipping.
-          self.prefilled_chunks.excl chunk_id
+          self.prefilled_chunks.del chunk_id
 
     self.tracked_delta_seqs[chunk_id] = zid
 
@@ -205,12 +204,11 @@ gdobj BuildNode of VoxelTerrain:
     ## block and today's paint-after-load path carries it.
     ## ENU_NO_PREFILL=1 disables the hook for prefill-vs-paint A/B measurement.
     result = new_pool_byte_array()
-    if not ?self.model or prefill_disabled or
-        (SERVER in state.local_flags and not server_prefill):
+    if not ?self.model or prefill_disabled:
       return
     let bytes = self.model.voxels.prefill_bytes(block_position)
     if bytes.len > 0:
-      self.prefilled_chunks.incl block_position
+      self.prefilled_chunks[block_position] = PackedChunk(data: bytes).voxel_count
       result = to_pool_byte_array(bytes)
 
   method on_block_loaded(chunk_id: Vector3) =
@@ -218,8 +216,17 @@ gdobj BuildNode of VoxelTerrain:
     if ?self.model:
       self.loaded_chunks.incl(chunk_id)
       # Consume the request-time hint: was this block prefilled with its data?
-      let prefilled = chunk_id in self.prefilled_chunks
-      self.prefilled_chunks.excl chunk_id
+      var prefill_credit = 0
+      let prefilled = self.prefilled_chunks.pop(chunk_id, prefill_credit)
+      if prefilled:
+        inc self.prefill_hits
+        # The engine expanded the served bytes into this block; the paints
+        # below are skipped for prefilled blocks, so credit their voxels here
+        # or rendered_voxel_count never converges on the model count.
+        self.model.rendered_voxel_count =
+          self.model.rendered_voxel_count + prefill_credit
+      else:
+        inc self.prefill_misses
 
       if SERVER notin state.local_flags:
         # Voxel paging: the engine's view streaming is the demand signal. A
@@ -253,8 +260,8 @@ gdobj BuildNode of VoxelTerrain:
         elif prefilled:
           # Prefilled: the streaming thread already expanded this content into the
           # engine block, which meshed once. Skip the redundant paint — this is the
-          # flash/double-mesh the whole change removes. (Not added to
-          # rendered_voxel_count: the engine, not build_node, drew it.)
+          # flash/double-mesh the whole change removes. (Counted above via
+          # prefill_credit, not here.)
           discard
         elif ?self.renderer.voxel_tool:
           painted = render_snapshot_direct(
@@ -342,7 +349,7 @@ gdobj BuildNode of VoxelTerrain:
           # Snapshot changed while the chunk is still loading: the prefilled
           # buffer was captured from the previous bytes, so drop the hint and let
           # on_block_loaded paint the fresh snapshot instead of skipping it.
-          self.prefilled_chunks.excl change.item.key
+          self.prefilled_chunks.del change.item.key
       elif removed and not modified:
         # Paged out or cleared (a rewrite is REMOVED+MODIFIED and skipped) —
         # clear it from the terrain, and from the ASAP buffer's terrain
@@ -384,7 +391,7 @@ gdobj BuildNode of VoxelTerrain:
             # Deltas changed before the chunk finished loading: the prefilled
             # buffer predates them, so drop the hint and let on_block_loaded
             # repaint the fresh state rather than skipping it.
-            self.prefilled_chunks.excl chunk_id
+            self.prefilled_chunks.del chunk_id
           # Watch for future deltas
           self.watch_delta_seq(chunk_id, delta_seq)
       elif removed:
@@ -540,6 +547,18 @@ gdobj BuildNode of VoxelTerrain:
         self.error_highlight_on = not self.error_highlight_on
         self.toggle_error_highlight_at = get_mono_time() + error_flash_time
         self.set_highlight()
+
+      # Opt-in perf sampling (ENU_PERF_LOG): per-terrain cumulative counters.
+      # `meshed` counts pipeline meshes actually applied — the number prefill
+      # is meant to halve (born-with-data = 1 mesh vs empty + paint + remesh).
+      if perf_log and get_mono_time() > self.next_stats_log:
+        self.next_stats_log = get_mono_time() + init_duration(seconds = 2)
+        let stats = self.get_statistics()
+        info "TERRAIN", unit = self.model.id,
+          meshed = parse_int($stats["updated_blocks"]),
+          dropped_meshes = parse_int($stats["dropped_block_meshs"]),
+          prefill_hits = self.prefill_hits,
+          prefill_misses = self.prefill_misses
 
       # Frame playback: the server is the single advancing authority; the
       # synced current_frame drives rendering on every side. Each side runs its

--- a/src/nodes/build_node.nim
+++ b/src/nodes/build_node.nim
@@ -78,7 +78,7 @@ gdobj BuildNode of VoxelTerrain:
 
   proc init*() =
     self.bind_signals self, "block_loaded", "block_unloaded",
-      "frame_mesh_baked"
+      "frame_mesh_baked", "mesh_block_created"
     self.default_view_distance = self.max_view_distance.int
 
   proc prepare_materials() =
@@ -165,6 +165,15 @@ gdobj BuildNode of VoxelTerrain:
           if i == rgb_material_index: hidden_rgb_shader else: hidden_shader
     else:
       self.visible = false
+
+  method on_mesh_block_created(chunk_id: Vector3) =
+    ## A mesh block was (re)created by viewer pairing. Any display state the
+    ## frame player recorded for it belonged to the previous block instance —
+    ## forget it, so the next flip re-queues and re-installs. Without this,
+    ## chunks re-entering pairing range keep a stale "shown" entry and render
+    ## whatever the pipeline meshed from data until their LOD target changes.
+    if ?self.frames:
+      self.frames.forget_display(chunk_id)
 
   method on_frame_mesh_baked(chunk_id: Vector3, tag: int, mesh: Mesh) =
     ## Godot signal callback (bind_signals "frame_mesh_baked") — hand the bake

--- a/src/nodes/build_node.nim
+++ b/src/nodes/build_node.nim
@@ -31,6 +31,11 @@ template each_material(self, i, m, body: untyped) =
 let prefill_disabled = get_env("ENU_NO_PREFILL") == "1"
   ## A/B switch: disable the enu_chunk_bytes prefill so paged-in blocks take
   ## the old paint-after-load path (perf comparison).
+let server_prefill = get_env("ENU_SERVER_PREFILL") == "1"
+  ## Experiment: let the SERVER (and therefore solo play) prefill paged-in
+  ## blocks too. Prefill shipped client-only; solo sessions still decode and
+  ## paint every chunk per voxel on main at page-in. Structurally the hook is
+  ## side-agnostic — flip this on to measure before changing the default.
 
 var build_scene {.threadvar.}: PackedScene
 var shader {.threadvar.}: Shader
@@ -200,7 +205,8 @@ gdobj BuildNode of VoxelTerrain:
     ## block and today's paint-after-load path carries it.
     ## ENU_NO_PREFILL=1 disables the hook for prefill-vs-paint A/B measurement.
     result = new_pool_byte_array()
-    if not ?self.model or SERVER in state.local_flags or prefill_disabled:
+    if not ?self.model or prefill_disabled or
+        (SERVER in state.local_flags and not server_prefill):
       return
     let bytes = self.model.voxels.prefill_bytes(block_position)
     if bytes.len > 0:

--- a/src/nodes/build_node_frames.nim
+++ b/src/nodes/build_node_frames.nim
@@ -56,13 +56,6 @@ type FramePlayer* = ref object
     ## prepared mesh swaps, held until the whole flip is ready. Data writes and
     ## key work drain incrementally, but the visible change is one atomic pass —
     ## chunks never flip at different times.
-  staged_keys: Table[Vector3, Hash]
-    ## the content key each staged mesh represents. `display` is only updated
-    ## at commit, and only when the install lands (or there was nothing to
-    ## show): set_block_mesh silently fails for unpaired mesh blocks, and
-    ## recording those as displayed left chunks blank-but-"shown" — the drain
-    ## skipped them until their target key changed (rivers vanishing for
-    ## seconds while walking pairing fringes).
   padded_bytes: PoolByteArray ## request_frame_mesh payload scratch
   commit_index: int
     ## which flip `staged` was prepared for. Prepare-ahead builds the NEXT flip
@@ -231,12 +224,12 @@ proc drain(self: FramePlayer) =
       if chunk_id notin frame.chunks:
         self.write_chunk(chunk_id, SnapshotData(), remesh = false, key = target)
         self.staged[chunk_id] = nil
-        self.staged_keys[chunk_id] = target
+        self.display[chunk_id] = target
       elif target in self.mesh_cache:
         self.touch_cached(target)
         self.write_chunk(chunk_id, frame.chunks[chunk_id], remesh = false, key = target)
         self.staged[chunk_id] = self.mesh_cache[target]
-        self.staged_keys[chunk_id] = target
+        self.display[chunk_id] = target
       else:
         # bake from data: the padded payload carries the frame's own neighbor
         # shell (or air when sealed), so the bake is valid no matter what any
@@ -378,13 +371,8 @@ proc commit_meshes(self: FramePlayer) =
       self.commit_index != self.model.current_frame:
     return
   for chunk_id, mesh in self.staged:
-    if self.terrain.set_block_mesh(chunk_id, mesh) or mesh.is_nil:
-      self.staged_keys.with_value(chunk_id, key):
-        self.display[chunk_id] = key[]
-    # a failed install (mesh block not paired) leaves the chunk un-displayed,
-    # so the next flip re-queues it and it installs once the block pairs
+    discard self.terrain.set_block_mesh(chunk_id, mesh)
   self.staged.clear()
-  self.staged_keys.clear()
   # prepare the NEXT flip now: its keys and data writes spread over the rest of
   # the interval, so the flip itself is just the swap pass above
   if self.model.frames_fps > 0 and self.model.frames.len > 1:
@@ -402,7 +390,6 @@ proc hide*(self: FramePlayer) =
   self.display.clear()
   self.queue.clear()
   self.staged.clear()
-  self.staged_keys.clear()
   self.decoded.clear()
   self.frame_data.clear()
   if self.dirty.len > 0 and ?self.renderer.voxel_tool:
@@ -460,7 +447,6 @@ proc drop_chunk*(self: FramePlayer, chunk_id: Vector3) =
   self.missing.del chunk_id
   self.queue.del chunk_id
   self.staged.del chunk_id
-  self.staged_keys.del chunk_id
   self.dirty.excl chunk_id
 
 proc tick*(self: FramePlayer) =

--- a/src/nodes/build_node_frames.nim
+++ b/src/nodes/build_node_frames.nim
@@ -292,6 +292,23 @@ proc effective_frame(
   else:
     0
 
+proc show_chunk*(self: FramePlayer, chunk_id: Vector3, index: int) =
+  ## Queue frame content for ONE freshly loaded chunk — on_block_loaded's
+  ## entry point. It used to run a full show() per paged-in chunk, and show()
+  ## walks every loaded chunk: O(loaded x incoming) on main made each 16m row
+  ## crossing a 250-550ms debug hitch (and boot O(n^2)). The chunk drains on
+  ## the next tick.
+  let frames = self.model.frames
+  if index < 0 or index >= frames.len or not ?self.renderer.voxel_tool:
+    return
+  let viewers = self.viewer_positions()
+  let chunk_index = self.effective_frame(chunk_id, index, frames.len, viewers)
+  let known = self.cached_key(chunk_index, chunk_id)
+  if known.is_some and chunk_id in self.display and
+      self.display[chunk_id] == known.get:
+    return
+  self.queue[chunk_id] = chunk_index
+
 proc show*(self: FramePlayer, index: int) =
   ## Queue the chunk work for frame `index`. Each loaded chunk picks an
   ## effective frame by distance (temporal LOD), then either matches what it

--- a/src/nodes/build_node_frames.nim
+++ b/src/nodes/build_node_frames.nim
@@ -56,6 +56,13 @@ type FramePlayer* = ref object
     ## prepared mesh swaps, held until the whole flip is ready. Data writes and
     ## key work drain incrementally, but the visible change is one atomic pass —
     ## chunks never flip at different times.
+  staged_keys: Table[Vector3, Hash]
+    ## the content key each staged mesh represents. `display` is only updated
+    ## at commit, and only when the install lands (or there was nothing to
+    ## show): set_block_mesh silently fails for unpaired mesh blocks, and
+    ## recording those as displayed left chunks blank-but-"shown" — the drain
+    ## skipped them until their target key changed (rivers vanishing for
+    ## seconds while walking pairing fringes).
   padded_bytes: PoolByteArray ## request_frame_mesh payload scratch
   commit_index: int
     ## which flip `staged` was prepared for. Prepare-ahead builds the NEXT flip
@@ -224,12 +231,12 @@ proc drain(self: FramePlayer) =
       if chunk_id notin frame.chunks:
         self.write_chunk(chunk_id, SnapshotData(), remesh = false, key = target)
         self.staged[chunk_id] = nil
-        self.display[chunk_id] = target
+        self.staged_keys[chunk_id] = target
       elif target in self.mesh_cache:
         self.touch_cached(target)
         self.write_chunk(chunk_id, frame.chunks[chunk_id], remesh = false, key = target)
         self.staged[chunk_id] = self.mesh_cache[target]
-        self.display[chunk_id] = target
+        self.staged_keys[chunk_id] = target
       else:
         # bake from data: the padded payload carries the frame's own neighbor
         # shell (or air when sealed), so the bake is valid no matter what any
@@ -371,8 +378,13 @@ proc commit_meshes(self: FramePlayer) =
       self.commit_index != self.model.current_frame:
     return
   for chunk_id, mesh in self.staged:
-    discard self.terrain.set_block_mesh(chunk_id, mesh)
+    if self.terrain.set_block_mesh(chunk_id, mesh) or mesh.is_nil:
+      self.staged_keys.with_value(chunk_id, key):
+        self.display[chunk_id] = key[]
+    # a failed install (mesh block not paired) leaves the chunk un-displayed,
+    # so the next flip re-queues it and it installs once the block pairs
   self.staged.clear()
+  self.staged_keys.clear()
   # prepare the NEXT flip now: its keys and data writes spread over the rest of
   # the interval, so the flip itself is just the swap pass above
   if self.model.frames_fps > 0 and self.model.frames.len > 1:
@@ -390,6 +402,7 @@ proc hide*(self: FramePlayer) =
   self.display.clear()
   self.queue.clear()
   self.staged.clear()
+  self.staged_keys.clear()
   self.decoded.clear()
   self.frame_data.clear()
   if self.dirty.len > 0 and ?self.renderer.voxel_tool:
@@ -447,6 +460,7 @@ proc drop_chunk*(self: FramePlayer, chunk_id: Vector3) =
   self.missing.del chunk_id
   self.queue.del chunk_id
   self.staged.del chunk_id
+  self.staged_keys.del chunk_id
   self.dirty.excl chunk_id
 
 proc tick*(self: FramePlayer) =

--- a/src/nodes/build_node_frames.nim
+++ b/src/nodes/build_node_frames.nim
@@ -441,6 +441,13 @@ proc reset*(self: FramePlayer) =
   self.hide()
   self.keys.clear()
 
+proc forget_display*(self: FramePlayer, chunk_id: Vector3) =
+  ## The chunk's mesh block was (re)created by pairing: whatever we recorded
+  ## as displayed belonged to the previous block instance. Clearing the entry
+  ## makes the next flip re-queue and re-install from the cache. In-flight
+  ## bakes stay valid (they're pure functions of content).
+  self.display.del chunk_id
+
 proc drop_chunk*(self: FramePlayer, chunk_id: Vector3) =
   ## A chunk paged out: forget its frame bookkeeping.
   self.display.del chunk_id

--- a/src/nodes/build_node_frames.nim
+++ b/src/nodes/build_node_frames.nim
@@ -67,6 +67,12 @@ type FramePlayer* = ref object
     ## being applied.
   keys: Table[int, Table[Vector3, Hash]] ## per frame, lazily built
   bytes: PoolByteArray ## reusable set_block_voxel_data payload
+  payloads: Table[Hash, PoolByteArray]
+    ## resolved set_block_voxel_data payloads per content key. Steady-state
+    ## playback rewrites the same frame contents per chunk forever; decoding
+    ## and resolving on every write was ~20% of main during paging. ~8 KB per
+    ## key (sealed builds dedupe hard; unsealed shell-aware keys fragment
+    ## this cache but stay correct).
   dirty: HashSet[Vector3] ## terrain data differs from live state
   mesh_lru: Table[Hash, int] ## last-touched tick per cached mesh
   lru_tick: int
@@ -154,11 +160,26 @@ proc key_for(self: FramePlayer, index: int, chunk_id: Vector3): Hash =
     )
   self.keys.mget_or_put(index, Table[Vector3, Hash]())[chunk_id] = result
 
+proc payload_for(
+    self: FramePlayer, key: Hash, snapshot: SnapshotData
+): PoolByteArray =
+  ## The resolved u16 payload for a content key, decoded and resolved once.
+  self.payloads.with_value(key, cached):
+    return cached[]
+  result = new_pool_byte_array()
+  result.set_len(CHUNK_VOLUME * 2)
+  fill_chunk_type_bytes(result, snapshot, self.resolver)
+  if self.payloads.len >= 8192: # ~64 MB; rebuilding is cheap, unlike meshes
+    self.payloads.clear()
+  self.payloads[key] = result
+
 proc write_chunk(
-    self: FramePlayer, chunk_id: Vector3, snapshot: SnapshotData, remesh: bool
+    self: FramePlayer, chunk_id: Vector3, snapshot: SnapshotData, remesh: bool,
+    key: Hash,
 ) =
-  fill_chunk_type_bytes(self.bytes, snapshot, self.resolver)
-  discard self.terrain.set_block_voxel_data(chunk_id, self.bytes, remesh)
+  discard self.terrain.set_block_voxel_data(
+    chunk_id, self.payload_for(key, snapshot), remesh
+  )
   self.dirty.incl chunk_id
 
 proc drain(self: FramePlayer) =
@@ -184,12 +205,12 @@ proc drain(self: FramePlayer) =
       let frame = frames[chunk_index]
       self.missing.del chunk_id
       if chunk_id notin frame.chunks:
-        self.write_chunk(chunk_id, SnapshotData(), remesh = false)
+        self.write_chunk(chunk_id, SnapshotData(), remesh = false, key = target)
         self.staged[chunk_id] = nil
         self.display[chunk_id] = target
       elif target in self.mesh_cache:
         self.touch_cached(target)
-        self.write_chunk(chunk_id, frame.chunks[chunk_id], remesh = false)
+        self.write_chunk(chunk_id, frame.chunks[chunk_id], remesh = false, key = target)
         self.staged[chunk_id] = self.mesh_cache[target]
         self.display[chunk_id] = target
       else:
@@ -200,7 +221,7 @@ proc drain(self: FramePlayer) =
         # path): if the engine destroys and recreates this mesh block (viewer
         # churn), pairing remeshes it from data — empty data would blank a chunk
         # the display map already counts as shown, forever.
-        self.write_chunk(chunk_id, frame.chunks[chunk_id], remesh = false)
+        self.write_chunk(chunk_id, frame.chunks[chunk_id], remesh = false, key = target)
         fill_padded_chunk_bytes(
           self.padded_bytes,
           self.decoded.mget_or_put(chunk_index, DecodedChunks()),

--- a/src/nodes/build_node_frames.nim
+++ b/src/nodes/build_node_frames.nim
@@ -66,6 +66,13 @@ type FramePlayer* = ref object
     ## computation inside the drain budget. Pruned each flip to the indexes still
     ## being applied.
   keys: Table[int, Table[Vector3, Hash]] ## per frame, lazily built
+  frame_data: Table[int, ref FrameData]
+    ## one deep copy of each active frame: the synced EdTable returns
+    ## FrameData BY VALUE, so reading `model.frames[index]` copies every
+    ## chunk's packed string (MBs). The drain and key paths were doing that
+    ## per chunk access — hundreds of MB copied per flip, the dominant
+    ## main-thread cost of paging hitches on release builds. Pruned with
+    ## `decoded` each flip; invalidated whenever frames change.
   bytes: PoolByteArray ## reusable set_block_voxel_data payload
   payloads: Table[Hash, PoolByteArray]
     ## resolved set_block_voxel_data payloads per content key. Steady-state
@@ -139,6 +146,15 @@ proc cached_key(self: FramePlayer, index: int, chunk_id: Vector3): Option[Hash] 
   else:
     none(Hash)
 
+proc frame_at(self: FramePlayer, index: int): ref FrameData =
+  ## The frame's data via the local copy — one deep copy per active index,
+  ## never per access.
+  self.frame_data.with_value(index, cached):
+    return cached[]
+  result = new FrameData
+  result[] = self.model.frames[index]
+  self.frame_data[index] = result
+
 proc key_for(self: FramePlayer, index: int, chunk_id: Vector3): Hash =
   ## The chunk's content key, computed on first use inside the drain budget and
   ## memoized. Sealed builds key on the chunk's own bytes (borders always bake);
@@ -147,15 +163,16 @@ proc key_for(self: FramePlayer, index: int, chunk_id: Vector3): Hash =
   if index in self.keys and chunk_id in self.keys[index]:
     return self.keys[index][chunk_id]
   if self.model.sealed_frames:
+    let frame = self.frame_at(index)
     result =
-      if chunk_id in self.model.frames[index].chunks:
-        hash(self.model.frames[index].chunks[chunk_id].data)
+      if chunk_id in frame.chunks:
+        hash(frame.chunks[chunk_id].data)
       else:
         Hash(0)
   else:
     result = chunk_frame_key(
       self.decoded.mget_or_put(index, DecodedChunks()),
-      self.model.frames[index],
+      self.frame_at(index)[],
       chunk_id,
     )
   self.keys.mget_or_put(index, Table[Vector3, Hash]())[chunk_id] = result
@@ -202,7 +219,7 @@ proc drain(self: FramePlayer) =
       continue
     let target = self.key_for(chunk_index, chunk_id)
     if chunk_id notin self.display or self.display[chunk_id] != target:
-      let frame = frames[chunk_index]
+      let frame = self.frame_at(chunk_index)
       self.missing.del chunk_id
       if chunk_id notin frame.chunks:
         self.write_chunk(chunk_id, SnapshotData(), remesh = false, key = target)
@@ -225,7 +242,7 @@ proc drain(self: FramePlayer) =
         fill_padded_chunk_bytes(
           self.padded_bytes,
           self.decoded.mget_or_put(chunk_index, DecodedChunks()),
-          frame,
+          frame[],
           chunk_id,
           self.resolver,
           sealed = self.model.sealed_frames,
@@ -306,6 +323,9 @@ proc show*(self: FramePlayer, index: int) =
   for cached_index in self.decoded.keys.to_seq:
     if cached_index notin active:
       self.decoded.del cached_index
+  for cached_index in self.frame_data.keys.to_seq:
+    if cached_index notin active:
+      self.frame_data.del cached_index
   let flip_took = (get_mono_time() - flip_start).in_milliseconds
   if flip_took > 100:
     info "frame flip slow",
@@ -371,6 +391,7 @@ proc hide*(self: FramePlayer) =
   self.queue.clear()
   self.staged.clear()
   self.decoded.clear()
+  self.frame_data.clear()
   if self.dirty.len > 0 and ?self.renderer.voxel_tool:
     for chunk_id in self.dirty:
       if chunk_id notin self.loaded_chunks[]:
@@ -411,6 +432,7 @@ proc on_frames_changed*(self: FramePlayer) =
   ## but per-frame key tables must recompute.
   self.keys.clear()
   self.decoded.clear()
+  self.frame_data.clear()
   self.display.clear()
   self.render(self.model.current_frame)
 

--- a/src/types.nim
+++ b/src/types.nim
@@ -323,6 +323,12 @@ type
     local_edits*: Table[Vector3, Table[Vector3, VoxelInfo]]
     pending_chunks*:
       Table[Vector3, seq[tuple[pos: Vector3, voxel: PackedVoxel]]]
+    pending_snapshots*: Table[Vector3, SnapshotData]
+      ## Whole chunks staged by the bulk load path (adopt_edit_chunks),
+      ## published by the same paced flush_dirty_chunks the per-voxel buffer
+      ## uses. Value = the stored blob to publish verbatim, or empty to
+      ## re-encode from the cache (holes/deltas changed it). Publishing all
+      ## chunks eagerly at load overshot the sync channel in one burst.
     pending_edits*: Table[Vector3, seq[tuple[pos: Vector3, voxel: PackedVoxel]]]
     on_chunk_created*: proc(chunk_id: Vector3) {.gcsafe.}
     snapshots_flushed*: int

--- a/src/types.nim
+++ b/src/types.nim
@@ -449,6 +449,10 @@ type
       ## keeps keys contiguous). A table rather than a seq so replace is one
       ## keyed op — ed's positional seq ops don't sync order-safely. Synced
       ## once as data; playback only moves `current_frame`.
+    frames_dirty*: bool
+      ## Frames changed since the last save_frames (host-local, not synced).
+      ## Loaded frames start clean: re-encoding 24 untouched frames on every
+      ## level save dominated debug-build load times.
     current_frame_value*: EdValue[int]
       ## Displayed frame, or -1 for the live voxel state. Display-only:
       ## queries and collisions keep reading the live voxels (use


### PR DESCRIPTION
Performance and correctness fixes from building the 0.3 course island level (large frame-animated water, 2M+ voxel terrain). Also includes `bin/demos/demo_island.nim`, the generator used to author the level; the level content itself ships separately.

## Frame animation pipeline
- Deliver frame bakes even when the render block isn't loaded (engine) — bakes for unpaired blocks were silently dropped and re-requested forever (missing≈52, harvests=0, pinned)
- Assemble frame-bake meshes (and their collision shapes) on the bake worker instead of main (engine)
- Memoize color-slot resolution and cache resolved payloads per key; stop deep-copying FrameData per chunk access
- Forget display state when a mesh block is (re)created (`mesh_block_created` signal), so chunks re-entering pairing range re-install their frame instead of showing stale pipeline content
- `on_block_loaded` queues only the fresh chunk (`show_chunk`) instead of a full `show()` walk — this was the metronomic walk hitch: 250–550 ms debug frame pairs every chunk row, ~100 ms release. After: zero >50 ms frames on the same walk, debug build

## Load path
- Adopt persisted edit chunks in bulk instead of replaying every voxel through `add_voxel` (~6 s debug for 2.1M voxels → bulk install)
- Stage bulk-adopted chunks through the paced flusher so the initial publish can't flood the sync channel
- Stop saving the level while it's loading; skip untouched frame saves

## Prefill
- `enu_chunk_bytes` now serves whenever main's store holds the chunk, on any side — the server/client distinction is gone. Resident chunks are prefilled at page-in (born with data, one mesh); misses paint on arrival as before. Consumed prefill hints credit their voxels to `rendered_voxel_count`, which the skipped paints would otherwise have counted (caught by the ASAP render-race world test). `ENU_NO_PREFILL=1` is the A/B escape hatch

## Instrumentation (opt-in)
- `ENU_PERF_LOG`: per-build `TERRAIN` line with cumulative real meshes (`updated_blocks`, now actually counted engine-side) and prefill hit/miss; VoxelServer in-flight queue gauges on the `PERF` line
- `ENU_SLOW_FRAME_MS`: configurable slow-frame threshold

## vendor/godot_voxel
Pin bump `14f0975` → `3ba5a66` ([frame-bake-perf](https://github.com/dsrw/godot_voxel/tree/frame-bake-perf)): frame-bake delivery fix, worker-side bake assembly, `mesh_block_created` signal, `updated_blocks` counts real pipeline mesh applies.

Tests: `nim test` 11/11, `nim test_world` 31/31.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_016jihGPHAowswV9eQmVp5Xr