### PR TITLE
level: drop unused enu_version, bump format_version to 1.0.0

### DIFF
--- a/src/models/serializers.nim
+++ b/src/models/serializers.nim
@@ -43,14 +43,13 @@ const PLAYERS_SENTINEL* = "PLAYERS"
   ## immediate physics at start_transform, no splash.
 
 type LevelInfo = object
-  enu_version*, format_version*: string
+  format_version*: string
   load_order*: seq[string]
   show_prototypes*: bool
   show_tools*: bool
   start_transform*: Transform
 
 proc from_json_hook*(self: var LevelInfo, json: JsonNode) =
-  self.enu_version = json{"enu_version"}.get_str
   self.format_version = json{"format_version"}.get_str
 
   if "load_order" in json:
@@ -747,8 +746,7 @@ proc save_level*(level_dir: string, save_all = false, force = false) =
       debug "load_order content", load_order = sorted_scripts
 
     let level = LevelInfo(
-      enu_version: enu_version,
-      format_version: "v0.9.2",
+      format_version: "1.0.0",
       load_order: sorted_scripts,
       show_prototypes: state.show_prototypes,
       show_tools: state.show_tools,


### PR DESCRIPTION
## What

- Remove `enu_version` from `LevelInfo`, its load hook, and the save path in `src/models/serializers.nim`.
- Bump the saved `format_version` from `v0.9.2` → `1.0.0`.

## Why

`enu_version` was written on every save as the running build's `git describe` and **never read back** — no migration or gating ever consumed it. Because the string changed with every build, it churned `level.json` whenever a different build re-saved a level (and, since the save is guarded by `write_file_if_changed`, it was the reason the file rewrote at all when nothing meaningful changed).

`format_version` is the real, stable migration hook. Bumping it to `1.0.0` for 0.3 lets us gate on `v0.9.2` vs `1.0.0` in `from_json_hook` later if the 0.2.2 levels turn out to need migrating.

## Notes

- **Backward compatible:** old levels still load — the stray `enu_version` key is ignored (`json{}` safe-nav), and their on-disk `format_version` stays `v0.9.2` until re-saved. Shipped 0.2.2 level files are intentionally left as-is so they remain a migration test corpus.
- The app-version const in `core.nim` (used by the About dialog) is untouched — only the level field is removed.
- `format_version` is still only read *into* `LevelInfo`, not yet acted on; wiring up actual load-time migration is a follow-up once we know what 0.2.2 levels need.

## Testing

- `nim build` clean, `nim test` 11/11.
- Live save-and-reload on the course/island level produced a `level.json` leading with `"format_version": "1.0.0"` and zero `enu_version` occurrences.