### PR TITLE
fix: make `say` target the running script's thing, not enu_target

### DIFF
--- a/share/vmlib/enu/signs.nim
+++ b/share/vmlib/enu/signs.nim
@@ -100,4 +100,9 @@ template say*(
     size = float.high,
     billboard = none(bool),
 ): Sign =
-  enu_target.say(message, more, width, height, size, billboard)
+  # Target the running script's own thing via `active_thing()`, not the
+  # injected `enu_target` local — the latter isn't captured into user-defined
+  # procs in the VM, so `say` from inside a proc would silently target nothing.
+  # `say` belongs to the script's thing (a thing speaks as itself), so this is
+  # also the semantically correct target even mid-`move`/`build`.
+  active_thing().say(message, more, width, height, size, billboard)

--- a/share/vmlib/enu/signs.nim
+++ b/share/vmlib/enu/signs.nim
@@ -100,9 +100,4 @@ template say*(
     size = float.high,
     billboard = none(bool),
 ): Sign =
-  # Target the running script's own thing via `active_thing()`, not the
-  # injected `enu_target` local — the latter isn't captured into user-defined
-  # procs in the VM, so `say` from inside a proc would silently target nothing.
-  # `say` belongs to the script's thing (a thing speaks as itself), so this is
-  # also the semantically correct target even mid-`move`/`build`.
   active_thing().say(message, more, width, height, size, billboard)


### PR DESCRIPTION
## What

`say` (the no-explicit-target template form — `say "hi"`, `say msg, more`) targeted nothing when called from inside a user-defined proc, so the sign was never created.

## Why

The `say` template expanded to `enu_target.say(...)`. `enu_target` is an injected `var` (`class_macros.nim`) initialized to the script's own thing. The Nim VM doesn't capture that injected local into user-defined procs, so inside a proc `enu_target` didn't resolve to the script's thing and nothing happened. `turn`/`place`/`box` don't hit this because they resolve through `active_thing()` — a host-maintained accessor set by `register_active(me)` at script start.

This surfaced while building a branching-dialog system: a bot's `render()` proc calls `say` to update its sign, and the bubble never appeared. A direct `say` in a state body worked; the identical call wrapped in a proc did not.

## Fix

Resolve `say` through `active_thing()`, like the other turtle/query commands. It's also the semantically correct target — a thing speaks as itself — so this holds even mid-`move`/`build`.

## Testing

Verified in-world: a bot proc calling `say` now renders its sign (previously nothing). Existing top-level `say` calls are unaffected — at the top level `enu_target == active_thing()`.

Note: the same VM-capture limitation still affects the turtle-movement templates (`forward`, `up`, …) inside user procs; those can't simply switch to `active_thing()` because `move`/`build` deliberately retarget `enu_target`. Tracked separately.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_013JP2Rq7yVnRvmABhvckqqd
