### PR TITLE
fix: keep the toolbar pinned to the bottom after a tools change

### DIFF
--- a/src/ui/toolbar.nim
+++ b/src/ui/toolbar.nim
@@ -1,6 +1,6 @@
 import
   godotapi/[
-    h_box_container, scene_tree, scene_tree_tween, property_tweener,
+    h_box_container, control, scene_tree, scene_tree_tween, property_tweener,
     method_tweener, tween, button, image_texture,
   ]
 import pkg/[godot]
@@ -18,8 +18,6 @@ gdobj Toolbar of HBoxContainer:
     waiting = false
     zid: EID
     tween: SceneTreeTween
-    rest_y: float
-    rest_y_set: bool
 
   method ready*() =
     self.bind_signals self, "action_changed"
@@ -74,26 +72,30 @@ gdobj Toolbar of HBoxContainer:
   proc animate_tools() =
     # Slide the toolbar down and back up, swapping in the updated tool set at the
     # bottom — matching the Settings slide-up look (vertical only).
-    if not self.rest_y_set:
-      self.rest_y = self.rect_position.y
-      self.rest_y_set = true
+    #
+    # Derive the resting top-y from the anchored layout every time instead of
+    # caching one read: the toolbar is bottom-anchored with a 5px bottom margin
+    # (GUI.tscn), so its top rests at parent_height - 5 - its own height. Caching
+    # a single early rect_position.y (before the window settled at final size)
+    # was leaving it stranded up-screen after a tools change.
+    let parent = self.get_parent() as Control
+    let rest = parent.rect_size.y - 5.0 - self.rect_size.y
     if ?self.tween:
       self.tween.kill
-    self.rect_position = vec2(self.rect_position.x, self.rest_y)
+    self.rect_position = vec2(self.rect_position.x, rest)
 
     let drop = self.rect_size.y + 10.0
     self.tween = self.get_tree.create_tween()
     discard self.tween
       .tween_property(
-        self, "rect_position:y", (self.rest_y + drop).to_variant,
-        animation_duration,
+        self, "rect_position:y", (rest + drop).to_variant, animation_duration
       )
       .set_trans(TRANS_EXPO)
       .set_ease(EASE_IN_OUT)
     discard self.tween.tween_callback(self, "_apply_tools")
     discard self.tween
       .tween_property(
-        self, "rect_position:y", self.rest_y.to_variant, animation_duration
+        self, "rect_position:y", rest.to_variant, animation_duration
       )
       .set_trans(TRANS_EXPO)
       .set_ease(EASE_IN_OUT)


### PR DESCRIPTION
## What

The block/tool toolbar could end up stranded partway up the screen after the tool set changed (e.g. the course director grants tools ~1 s after level load), instead of sliding back to the bottom.

## Why

`animate_tools` slides the toolbar down, swaps the button set off-screen, and slides it back to `rest_y`. `rest_y` was captured **once**, lazily, from a single `rect_position.y` read (`if not rest_y_set: rest_y = rect_position.y`). If that first read happened before the window had settled at its final size, the cached value was too high — and since it was never refreshed, the toolbar returned to that wrong spot on every subsequent tools change.

## Fix

Derive the resting position from the anchored layout every time instead of caching a read. The toolbar is bottom-anchored with a 5px bottom margin (`GUI.tscn`), so its top rests at `parent_height - 5 - own_height`:

```nim
let parent = self.get_parent() as Control
let rest = parent.rect_size.y - 5.0 - self.rect_size.y
```

The `rest_y` / `rest_y_set` fields are gone. A resize or an early read can no longer strand it.

## Testing

Compiles clean (`nim build` → SuccessX). Behavior to confirm in-app: change tools a few times (or let the course director advance stages) and the toolbar stays pinned to the bottom.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_013JP2Rq7yVnRvmABhvckqqd
