### PR TITLE
default to tutorial/welcome when no world is configured

### DIFF
--- a/src/game.nim
+++ b/src/game.nim
@@ -485,7 +485,7 @@ gdobj Game of Node:
       font_size = uc.font_size ||= 20
       toolbar_size = uc.toolbar_size ||= 100
       world = uc.world ||= "tutorial"
-      level = uc.level ||= value.world & "-1"
+      level = uc.level ||= "welcome"
       run_server = uc.run_server ||= false
       show_stats = uc.show_stats ||= false
       megapixels = uc.megapixels ||= 2.0


### PR DESCRIPTION
## What

With no world/level configured, Enu now boots into **`tutorial/welcome`** instead of `tutorial/tutorial-1`.

## Why

The default world is already `tutorial`. The default *level* was `uc.level ||= value.world & "-1"` — i.e. `tutorial-1`. The welcome level (the relocated island course) is the intended first-run experience, so the default level is now simply `welcome`.

## Change

`src/game.nim`:

```nim
world = uc.world ||= "tutorial"
-level = uc.level ||= value.world & "-1"
+level = uc.level ||= "welcome"
```

An explicit `--level world/level` or a configured `world`/`level` still overrides it as before; this only changes the no-config default. (Pairs with the level move to `share/worlds/tutorial/welcome`.)

## Testing

Compiles (`nim build`). First-run should open `tutorial/welcome`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_013JP2Rq7yVnRvmABhvckqqd
