### PR TITLE
Level load fixes: PLAYERS gate ordering, start_transform format, SpawnGate cleanup

### DIFF
--- a/src/game.nim
+++ b/src/game.nim
@@ -73,6 +73,37 @@ const SPAWN_GATE_TIMEOUT = 30.seconds
 
 var environment_cache {.threadvar.}: Table[string, Environment]
 
+type SpawnGate = object
+  ## Loading-splash + spawn-gate state for this machine, driven by process() and
+  ## the LOAD_SCREEN watch. The LoadScreen covers the viewport from the first
+  ## frame; once a load starts (or `boot_deadline` fires) control of the splash
+  ## passes to the gate, which holds the player frozen at the spawn (SPAWN_HELD)
+  ## until this machine's copy of the pre-PLAYERS units has rendered.
+  booted: bool
+    ## Set once a load actually starts (or the boot timeout fires); the splash
+    ## then follows SPAWN_HELD rather than staying up unconditionally.
+  boot_deadline: MonoTime
+    ## Hand the splash to the gate no later than this, so it can never stick on
+    ## a client that never runs a local load.
+  ids: seq[string]
+    ## Build ids snapshotted the moment the server cleared LOAD_SCREEN — by ed
+    ## ordering, exactly this machine's copy of the pre-PLAYERS units. SPAWN_HELD
+    ## stays on until every one has rendered here.
+  active: bool
+    ## LOAD_SCREEN cleared: waiting for every gate unit to report rendered (the
+    ## wait_for_script check — pending_block_updates == 0, honest via the
+    ## engine's not-started floor) for two consecutive frames. The world stays
+    ## fully live; later units keep loading and don't gate.
+  warming: bool
+    ## Gate units settled: the 3D viewport now renders behind the opaque splash.
+    ## After two real draws the splash lifts — enabling and lifting in the same
+    ## frame showed a near-empty first frame.
+  settle_streak: int
+  warm_drawn_at: int64
+    ## get_frames_drawn() when warming began; lift at +2.
+  deadline: MonoTime
+  started: MonoTime
+
 gdobj Game of Node:
   var
     reticle: Control
@@ -89,32 +120,7 @@ gdobj Game of Node:
     node_controller: NodeController
     script_controller: ScriptController
     left_stick: VirtualJoystick
-    booted: bool
-      ## The LoadScreen covers the viewport from the first frame; once a load
-      ## actually starts (or a boot timeout fires) we hand control of the splash
-      ## to the spawn gate (SPAWN_HELD). See process().
-    boot_deadline: MonoTime
-    gate_ids: seq[string]
-      ## Build ids snapshotted the moment the server cleared LOAD_SCREEN — by
-      ## ed ordering, exactly this machine's copy of the pre-PLAYERS units.
-      ## SPAWN_HELD stays on until every one has rendered here.
-    gate_active: bool
-      ## LOAD_SCREEN cleared: waiting for every gate unit to report rendered
-      ## (the wait_for_script check — pending_block_updates == 0, honest via
-      ## the engine's not-started floor) for two consecutive frames. The world
-      ## stays fully live: the pre-PLAYERS units are already loaded AND
-      ## running, so their settled state is exactly what the reveal should
-      ## show; later units keep loading and don't gate.
-    gate_warming: bool
-      ## Gate units settled: the 3D viewport now renders behind the opaque
-      ## splash (see the splash block). After two real draws the splash lifts —
-      ## enabling and lifting in the same frame showed a near-empty first
-      ## frame.
-    gate_settle_streak: int
-    gate_warm_drawn_at: int64
-      ## get_frames_drawn() when warming began; lift at +2.
-    gate_deadline: MonoTime
-    gate_started: MonoTime
+    gate: SpawnGate
     screenshot_camera_node: Camera
     screenshot_viewport_node: Viewport
 
@@ -134,12 +140,12 @@ gdobj Game of Node:
     # every pre-PLAYERS unit reports rendered, then gives the renderer two
     # real draws behind the splash before lifting it. The deadline is a
     # loud backstop, never the normal path.
-    if self.gate_active:
+    if self.gate.active:
       let time = get_mono_time()
-      if not self.gate_warming:
+      if not self.gate.warming:
         var ready = true
         state.things.value.walk_tree proc(thing: Thing) =
-          if thing of Build and thing.id in self.gate_ids and
+          if thing of Build and thing.id in self.gate.ids and
               thing.pending_block_updates != 0:
             # Only wait on builds that have content to render: a content-less
             # build never starts streaming, so its not-started floor of 1
@@ -149,21 +155,21 @@ gdobj Game of Node:
                 b.frames.len > 0:
               ready = false
         if ready:
-          inc self.gate_settle_streak
+          inc self.gate.settle_streak
         else:
-          self.gate_settle_streak = 0
-        if self.gate_settle_streak >= 2 or time > self.gate_deadline:
-          if self.gate_settle_streak < 2:
+          self.gate.settle_streak = 0
+        if self.gate.settle_streak >= 2 or time > self.gate.deadline:
+          if self.gate.settle_streak < 2:
             error "spawn gate: deadline exceeded; revealing anyway",
-              gate_ids = self.gate_ids
-          self.gate_warming = true # the splash block enables the viewport
-          self.gate_warm_drawn_at = get_frames_drawn()
-      elif get_frames_drawn() >= self.gate_warm_drawn_at + 2:
+              gate_ids = self.gate.ids
+          self.gate.warming = true # the splash block enables the viewport
+          self.gate.warm_drawn_at = get_frames_drawn()
+      elif get_frames_drawn() >= self.gate.warm_drawn_at + 2:
         info "spawn gate: released",
-          waited_ms = (time - self.gate_started).in_milliseconds
-        self.gate_active = false
-        self.gate_warming = false
-        self.gate_ids = @[]
+          waited_ms = (time - self.gate.started).in_milliseconds
+        self.gate.active = false
+        self.gate.warming = false
+        self.gate.ids = @[]
         state.pop_flag SPAWN_HELD
     inc state.frame_count
     self.node_controller.drain_pending()
@@ -301,13 +307,13 @@ gdobj Game of Node:
     # render off while the player is held at the spawn, revealed the frame
     # the gate releases.
     if not self.load_screen.is_nil:
-      if not self.booted and (
+      if not self.gate.booted and (
         LOADING_LEVEL in state.global_flags or
-        LOAD_SCREEN in state.global_flags or time > self.boot_deadline
+        LOAD_SCREEN in state.global_flags or time > self.gate.boot_deadline
       ):
-        self.booted = true
+        self.gate.booted = true
       let show =
-        if self.booted: SPAWN_HELD in state.local_flags else: true
+        if self.gate.booted: SPAWN_HELD in state.local_flags else: true
       if self.load_screen.visible != show:
         self.load_screen.visible = show
       # The splash is opaque, so don't spend the GPU drawing the 3D viewport
@@ -315,7 +321,7 @@ gdobj Game of Node:
       # point is to render the finished scene behind the splash before lifting.
       if not self.scaled_viewport.is_nil:
         let mode =
-          if show and not self.gate_warming: UPDATE_DISABLED
+          if show and not self.gate.warming: UPDATE_DISABLED
           else: UPDATE_ALWAYS
         if self.scaled_viewport.render_target_update_mode != mode:
           self.scaled_viewport.render_target_update_mode = mode
@@ -709,7 +715,7 @@ gdobj Game of Node:
       # Hand the splash over to the LOAD_SCREEN flag once a load starts, or
       # after this timeout so it can never stick (e.g. a client that never runs
       # a local load).
-      self.boot_deadline = get_mono_time() + 8.seconds
+      self.gate.boot_deadline = get_mono_time() + 8.seconds
       self.stats = self.find_node("stats").as(Label)
       self.left_stick = find("LeftStick", VirtualJoystick)
       self.stats.visible = state.config.show_stats
@@ -744,27 +750,27 @@ gdobj Game of Node:
       if LOAD_SCREEN.added:
         # Splash phase: hold this machine's player frozen at the spawn while
         # the units ahead of the PLAYERS load_order step load and run.
-        self.gate_active = false
-        self.gate_warming = false
-        self.gate_settle_streak = 0
-        self.gate_ids = @[]
+        self.gate.active = false
+        self.gate.warming = false
+        self.gate.settle_streak = 0
+        self.gate.ids = @[]
         state.push_flag SPAWN_HELD
       elif LOAD_SCREEN.removed:
         # The worker pops this flag at the PLAYERS load_order step: every unit
         # before it is fully loaded and running. By ed's ordering all of that
         # is applied locally right now, so the builds present ARE the gate
         # set — wait for them to report rendered, then reveal (see
-        # gate_active in process()).
+        # gate.active in process()).
         var ids: seq[string]
         state.things.value.walk_tree proc(thing: Thing) =
           if thing of Build:
             ids.add thing.id
-        self.gate_ids = ids
-        self.gate_active = true
-        self.gate_warming = false
-        self.gate_settle_streak = 0
-        self.gate_started = get_mono_time()
-        self.gate_deadline = self.gate_started + SPAWN_GATE_TIMEOUT
+        self.gate.ids = ids
+        self.gate.active = true
+        self.gate.warming = false
+        self.gate.settle_streak = 0
+        self.gate.started = get_mono_time()
+        self.gate.deadline = self.gate.started + SPAWN_GATE_TIMEOUT
         info "spawn gate: waiting for local render", gate_ids = ids
 
     state.player_value.changes:

--- a/src/models/serializers.nim
+++ b/src/models/serializers.nim
@@ -455,14 +455,20 @@ proc load_things*(parent: Thing, load_order: seq[string] = newSeq[string]()) =
 
   var sorted_scripts = load_order
 
-  # Things missing from the saved list get slotted in: script-less data
-  # units (the terrain and other pure-JSON builds) load FIRST — they have
-  # no dependencies and they're the ground the player needs under their
-  # feet — while unlisted scripted things append at the end as before.
+  # Things missing from the saved list get slotted in. Only a gating level —
+  # one whose PLAYERS sentinel sits past the front — pulls script-less data
+  # units (the terrain and other pure-JSON builds the player needs underfoot)
+  # ahead of the gate; unlisted scripted things always append at the end. With
+  # no gate (PLAYERS first, including a level that had no sentinel and got one
+  # forced to the front) everything appends, so PLAYERS stays first and nothing
+  # loads ahead of the reveal.
+  let gating = sorted_scripts.find(PLAYERS_SENTINEL) > 0
   for (id, dir, _, script) in loaded_data:
     if script notin sorted_scripts:
-      if not file_exists(state.config.script_dir / script & ".nim") and
-          not file_exists(dir / script & ".nim"):
+      let script_less =
+        not file_exists(state.config.script_dir / script & ".nim") and
+        not file_exists(dir / script & ".nim")
+      if gating and script_less:
         sorted_scripts.insert(script, 0)
       else:
         sorted_scripts.add script
@@ -745,55 +751,79 @@ proc save_world_support*(world_dir: string) =
 proc save_level*(level_dir: string, save_all = false, force = false) =
   if (SERVER in state.local_flags and TEST_MODE notin state.local_flags) or force:
     # The whole level is in load_order now — script-less units (terrain and
-    # other pure-JSON builds) included, keyed by id. Build the dependency
-    # graph and the error set (scripted units only), then order every
-    # non-ephemeral unit: keep the order they currently have (state.load_order,
-    # set at load), append genuinely new units at the end, and let topo_sort
-    # pull dependencies earlier where a script requires it.
+    # other pure-JSON builds) included, keyed by id. Build the dependency graph,
+    # the error set, and the script-less set (all scripted-vs-not decisions key
+    # off script_ctx), then order every non-ephemeral unit.
     var graph = initTable[string, seq[string]]()
-    var error_nodes = newSeq[string]()
     var present: seq[string] # every non-ephemeral unit id, in things order
     var is_error = initHashSet[string]()
+    var script_less = initHashSet[string]()
     for thing in state.things:
       if EPHEMERAL in thing.global_flags:
         continue
       let name = thing.id
       if name notin present:
         present.add name
-      if thing.script_ctx != nil:
-        if thing.errors.value.len > 0:
-          if name notin is_error:
-            is_error.incl name
-            error_nodes.add name
-        elif thing.script_ctx.dependencies.len > 0:
-          var deps: seq[string] = @[]
-          for dep in thing.script_ctx.dependencies:
-            let dep_name = dep.extract_filename
-            deps.add(
-              if dep_name.ends_with(".nim"): dep_name[0 .. ^5] else: dep_name
-            )
-          graph[name] = deps
+      if thing.script_ctx == nil:
+        script_less.incl name
+      elif thing.errors.value.len > 0:
+        is_error.incl name
+      elif thing.script_ctx.dependencies.len > 0:
+        var deps: seq[string] = @[]
+        for dep in thing.script_ctx.dependencies:
+          let dep_name = dep.extract_filename
+          deps.add(
+            if dep_name.ends_with(".nim"): dep_name[0 .. ^5] else: dep_name
+          )
+        graph[name] = deps
 
-    # Preserve the existing order; new units go to the end. The PLAYERS
-    # sentinel isn't a unit but its position is the spawn gate — keep it.
-    var sort_nodes = newSeq[string]()
+    # The PLAYERS sentinel is the spawn gate, and it's a hard partition: units
+    # before it are the pre-reveal set, units after stream in behind the player.
+    # Keep every unit on the side it's already on so the sentinel never drifts —
+    # a non-gating level (PLAYERS first) stays non-gating. New units append to a
+    # side: script-less ones join the gate set only when the level already
+    # gates; scripted ones always land after. Errors and topo ordering happen
+    # within a side, so a transiently-broken unit can't jump ahead of PLAYERS.
+    let gate_idx = state.load_order.find(PLAYERS_SENTINEL)
+    let gating = gate_idx > 0
+    var pre, post: seq[string]
     var seen = initHashSet[string]()
-    for name in state.load_order & present:
-      if name notin seen and name notin is_error and
-          (name == PLAYERS_SENTINEL or name in present):
-        seen.incl name
-        sort_nodes.add name
+    for i, name in state.load_order:
+      if name == PLAYERS_SENTINEL or name notin present or name in seen:
+        continue
+      seen.incl name
+      if gate_idx >= 0 and i < gate_idx:
+        pre.add name
+      else:
+        post.add name
+    for name in present:
+      if name in seen:
+        continue
+      seen.incl name
+      if gating and name in script_less:
+        pre.add name
+      else:
+        post.add name
+
+    proc ordered(side: seq[string]): seq[string] =
+      # Errored units keep their given order — excluded from the graph sort to
+      # dodge circular-dependency blowups — ahead of the topo-sorted rest.
+      var errs, rest: seq[string]
+      for name in side:
+        if name in is_error:
+          errs.add name
+        else:
+          rest.add name
+      errs & topo_sort(rest, graph)
 
     var sorted_scripts: seq[string]
     try:
-      sorted_scripts = error_nodes & topo_sort(sort_nodes, graph)
+      sorted_scripts = ordered(pre) & @[PLAYERS_SENTINEL] & ordered(post)
       debug "saving level sorted scripts", scripts_len = sorted_scripts.len
     except ValueError as e:
       error "Cannot save level script order due to circular dependency",
         error = e.msg
-      sorted_scripts = error_nodes & sort_nodes # fallback: save unordered
-    if PLAYERS_SENTINEL notin sorted_scripts:
-      sorted_scripts.insert(PLAYERS_SENTINEL, 0)
+      sorted_scripts = pre & @[PLAYERS_SENTINEL] & post # fallback: unordered
     state.load_order = sorted_scripts
 
     if sorted_scripts.len > 0:

--- a/src/models/serializers.nim
+++ b/src/models/serializers.nim
@@ -748,6 +748,34 @@ proc save_world_support*(world_dir: string) =
       "*/generated/\n*/nim.cfg\n*/project.nim\n*/project.nimble\n",
   )
 
+proc level_json(self: LevelInfo): string =
+  # Hand-formatted so start_transform matches the thing files — each basis row
+  # and the origin on a single line — rather than std/json's pretty output,
+  # which breaks every vector across one-number-per-line.
+  let order =
+    if self.load_order.len > 0:
+      self.load_order.map_it(it.escape_json).join(",\n").indent(4)
+    else:
+      ""
+  let basis =
+    self.start_transform.basis.elements.map_it($[it.x, it.y, it.z]).join(",\n")
+  let o = self.start_transform.origin
+  \"""{{
+  "format_version": "{self.format_version}",
+  "load_order": [
+{order}
+  ],
+  "show_prototypes": {self.show_prototypes},
+  "show_tools": {self.show_tools},
+  "start_transform": {{
+    "basis": [
+{basis.indent(6)}
+    ],
+    "origin": {$[o.x, o.y, o.z]}
+  }}
+}}
+"""
+
 proc save_level*(level_dir: string, save_all = false, force = false) =
   if (SERVER in state.local_flags and TEST_MODE notin state.local_flags) or force:
     # The whole level is in load_order now — script-less units (terrain and
@@ -836,8 +864,7 @@ proc save_level*(level_dir: string, save_all = false, force = false) =
       show_tools: state.show_tools,
       start_transform: state.start_transform,
     )
-    write_file_if_changed level_dir / "level.json",
-      jsonutils.to_json(level).pretty
+    write_file_if_changed level_dir / "level.json", level.level_json
     save_ide_support(level_dir, sorted_scripts)
     save_world_support(state.config.world_dir)
 


### PR DESCRIPTION
Fixes surfaced while updating `tutorial-1` for 0.3, plus a cleanup of the boot-gate code.

## `PLAYERS` load_order positioning + gate
The `PLAYERS` sentinel in `load_order` is the spawn gate: units before it render behind the splash before the player gets control; units after stream in behind them. A level with no gate should keep `PLAYERS` first and never raise the splash. Two bugs drifted it into the middle of a freshly generated order:

- **`load_things`** inserted every unlisted script-less unit at index 0, shoving a front-placed `PLAYERS` rightward. Now script-less units only slot ahead of the sentinel when the level *already* gates (`PLAYERS` past the front); otherwise everything appends and `PLAYERS` stays first.
- **`save_level`** prepended errored units ahead of `PLAYERS`. Since scripts spawn child builds that transiently error mid-load, that write stuck and `topo_sort` compounded it across successive saves. The sentinel is now a **hard partition**: units keep to the side they're already on, and error/topo ordering happens *within* a side, so it can't drift. An absent sentinel lands `PLAYERS` first.

Net effect: a non-gating level (e.g. old `tutorial-1`) regenerates with `PLAYERS` at index 0 and no splash; an authored gate (`tutorial/welcome`, `PLAYERS` at 9/45) is preserved exactly.

## `start_transform` format
`level.json` was written with `std/json`'s pretty printer, which breaks every vector onto one number per line. It's now hand-formatted (a small `level_json` proc) to match the thing json — each basis row and the origin on a single line.

## `SpawnGate` cleanup
The loading-splash + spawn-gate machine had grown to nine instance vars on `Game`. They're consolidated into a single `SpawnGate` object held as `gate` (mechanical, no behavior change).

## Verification
- `nim build` + `nim build_mcp` compile; `nim test`, `nim test_world`, `nim test_mcp` pass.
- Manual boots (via `--temp-workdir`, so the repo isn't touched): `tutorial-1` → `PLAYERS` first, no gate, single-line `start_transform`; `tutorial/welcome` → gate active on its 9-unit pre-reveal set, `PLAYERS` still at 9 after save.