### PR TITLE
Drop the loading splash before unit loading on an ungated level

### DIFF
--- a/src/models/serializers.nim
+++ b/src/models/serializers.nim
@@ -1156,6 +1156,14 @@ proc load_level*(worker: Worker, level_dir: string) =
   else:
     state.tools.clear()
 
+  # Ship the load-start decision to main before any unit loads. A gated level
+  # (LOAD_SCREEN up) holds the splash through the gate; an ungated one (PLAYERS
+  # first, no LOAD_SCREEN) has nothing to wait on, so main drops the splash here
+  # — before the first unit — rather than only once it happens to observe
+  # LOADING_LEVEL mid-load. The players are already at the spawn pose above, so
+  # the world simply streams in behind a settled camera.
+  Ed.thread_ctx.flush_buffers()
+
   worker.run_state_initializers()
 
   dont_join = true


### PR DESCRIPTION
Follow-up to #96. On a level with no spawn gate (`PLAYERS` first in `load_order`), the loading splash lingered into unit loading instead of dropping as soon as we know there's nothing to wait for.

## Cause
The load screen follows the spawn gate: once main observes a load start, it holds the splash only while `SPAWN_HELD` is up. An ungated level never raises `LOAD_SCREEN`, so there's no gate to wait on — but main only *learned* the load had started once it happened to observe `LOADING_LEVEL`, which isn't flushed until `load_things` reaches the `PLAYERS` step, i.e. right as the first unit lands.

## Fix
Flush the load-start decision (`LOADING_LEVEL`, plus `LOAD_SCREEN` for a gated level) right after the players are placed at the spawn and **before** `load_things` runs. An ungated load then drops the splash ahead of the first unit and the world streams in behind a settled camera; a gated load still raises `LOAD_SCREEN` and holds the splash through the reveal.

## Notes / caveat
Main's `process()` reacts a frame after the flush (the worker doesn't block on it), so the drop isn't instantaneous — but the signal now lands before unit loading rather than concurrent with it, and a unit's voxels render later still, so the splash is visually gone before anything appears. The boot splash covering Godot's own init (before `level.json` is read) is unchanged and expected.

## Verification
- `nim build` compiles; `nim test` passes.
- Manual boots (`--temp-workdir`): ungated `tutorial-1` drops the splash at load start; gated `tutorial/welcome` still holds it through the gate (`waiting for local render` on its 9-unit pre-reveal set).