### PR TITLE
Disable the loading screen + spawn gate entirely (stopgap)

### DIFF
--- a/src/game.nim
+++ b/src/game.nim
@@ -300,31 +300,22 @@ gdobj Game of Node:
     if SCENE_READY notin state.local_flags:
       state.push_flag SCENE_READY
 
-    # Loading splash. The LoadScreen node ships visible, so the boot goes
-    # straight from Godot's own splash into ours — no flash of empty scene +
-    # UI. It stays up unconditionally until a load actually starts (or an 8s
-    # safety timeout), then follows this machine's spawn gate: up and 3D
-    # render off while the player is held at the spawn, revealed the frame
-    # the gate releases.
-    if not self.load_screen.is_nil:
-      if not self.gate.booted and (
-        LOADING_LEVEL in state.global_flags or
-        LOAD_SCREEN in state.global_flags or time > self.gate.boot_deadline
-      ):
-        self.gate.booted = true
-      let show =
-        if self.gate.booted: SPAWN_HELD in state.local_flags else: true
-      if self.load_screen.visible != show:
-        self.load_screen.visible = show
-      # The splash is opaque, so don't spend the GPU drawing the 3D viewport
-      # behind it while it's up — except during the gate warm-up, when the
-      # point is to render the finished scene behind the splash before lifting.
-      if not self.scaled_viewport.is_nil:
-        let mode =
-          if show and not self.gate.warming: UPDATE_DISABLED
-          else: UPDATE_ALWAYS
-        if self.scaled_viewport.render_target_update_mode != mode:
-          self.scaled_viewport.render_target_update_mode = mode
+    # Loading screen + spawn gate DISABLED for now: never show the splash, always
+    # draw the viewport, never hold the player. load_level also stops raising
+    # LOAD_SCREEN, so the gate machinery above (and SPAWN_HELD) stays dormant. To
+    # re-enable, restore this block and the LOAD_SCREEN raise in load_level:
+    #
+    #   if not self.gate.booted and (LOADING_LEVEL in state.global_flags or
+    #       LOAD_SCREEN in state.global_flags or time > self.gate.boot_deadline):
+    #     self.gate.booted = true
+    #   let show =
+    #     if self.gate.booted: SPAWN_HELD in state.local_flags else: true
+    #   ...set load_screen.visible = show and the viewport update mode from show.
+    if not self.load_screen.is_nil and self.load_screen.visible:
+      self.load_screen.visible = false
+    if not self.scaled_viewport.is_nil and
+        self.scaled_viewport.render_target_update_mode != UPDATE_ALWAYS:
+      self.scaled_viewport.render_target_update_mode = UPDATE_ALWAYS
 
   proc rescale*() =
     let vp = self.get_viewport().size

--- a/src/models/serializers.nim
+++ b/src/models/serializers.nim
@@ -1113,23 +1113,19 @@ proc load_level*(worker: Worker, level_dir: string) =
     except Exception as e:
       error "Failed to load level", error = e
 
-  # The spawn gate: everything before PLAYERS in load_order must render
-  # before players get control. Missing sentinel = front = nothing to wait
-  # for (immediate physics, no splash). Raise the splash-phase signal only
-  # when there really are units ahead of the gate; load_things clears it at
-  # the PLAYERS step.
+  # The PLAYERS sentinel still partitions load_order (pre-reveal units first),
+  # but the spawn gate is DISABLED for now: we never raise LOAD_SCREEN, so main
+  # never shows the splash, never holds the player at the spawn (SPAWN_HELD), and
+  # never waits for the pre-PLAYERS units to render — the world just streams in
+  # live. To re-enable, restore the gate raise:
   #
-  # LOAD_SCREEN must be raised BEFORE LOADING_LEVEL: main hands the splash
-  # to the gate the moment either load flag lands, and holds it only if
-  # SPAWN_HELD is up — which its LOAD_SCREEN watch pushes. Raised in this
-  # order they ship in one batch and apply in order; raised after (the old
-  # entry-time LOADING_LEVEL push, then seconds of level seeding/parsing
-  # before this point) LOADING_LEVEL could land a batch early and flash a
-  # frame of the empty 3D scene between the boot splash and the gate.
+  #   if load_order.find(PLAYERS_SENTINEL) > 0:
+  #     state.global_flags += LOAD_SCREEN   # must precede LOADING_LEVEL
+  #
+  # (and the splash block in game.process). LOADING_LEVEL still fires — it's the
+  # internal "level loading" state other nodes key off, not the loading screen.
   if PLAYERS_SENTINEL notin load_order:
     load_order.insert(PLAYERS_SENTINEL, 0)
-  if load_order.find(PLAYERS_SENTINEL) > 0:
-    state.global_flags += LOAD_SCREEN
   state.global_flags += LOADING_LEVEL
   state.push_flag LOADING_SCRIPT
   state.config = config

--- a/src/models/serializers.nim
+++ b/src/models/serializers.nim
@@ -1156,6 +1156,14 @@ proc load_level*(worker: Worker, level_dir: string) =
   else:
     state.tools.clear()
 
+  # Ship the load-start decision to main before any unit loads. A gated level
+  # (LOAD_SCREEN up) holds the splash through the gate; an ungated one (PLAYERS
+  # first, no LOAD_SCREEN) has nothing to wait on, so main drops the splash here
+  # — before the first unit — rather than only once it happens to observe
+  # LOADING_LEVEL mid-load. The players are already at the spawn pose above, so
+  # the world simply streams in behind a settled camera.
+  Ed.thread_ctx.flush_buffers()
+
   worker.run_state_initializers()
 
   dont_join = true


### PR DESCRIPTION
Temporary blunt disable, by request: never raise `LOAD_SCREEN` and never show the load screen under any condition.

## Effect
- No level gates. The splash never appears, the player is never held at the spawn (`SPAWN_HELD` stays down), and the world streams in live while the camera sits at the spawn pose.
- `LOADING_LEVEL` still fires — it's the internal "level loading" state other nodes key off, not the loading screen.

## Reversal
Both edit sites carry restore notes:
- `load_level` (serializers): restore the `PLAYERS past the front → += LOAD_SCREEN` raise.
- `game.process` (game.nim): restore the splash `show`/visibility + viewport-update block.

## Why blunt
This is a stopgap while we chase why the gate felt like it lingered. Worth noting for the eventual real fix: `tutorial/welcome` gates **by design** (`PLAYERS` at index 9 of 45), whereas `tutorial-1` is ungated (`PLAYERS` at 0). #97 only ever affected PLAYERS-first levels, so it never changed the `welcome` experience.