### PR TITLE
Fix ungated boot splash lingering ~8s (flip booted off the flags watch)

### DIFF
--- a/src/game.nim
+++ b/src/game.nim
@@ -80,8 +80,9 @@ type SpawnGate = object
   ## passes to the gate, which holds the player frozen at the spawn (SPAWN_HELD)
   ## until this machine's copy of the pre-PLAYERS units has rendered.
   booted: bool
-    ## Set once a load actually starts (or the boot timeout fires); the splash
-    ## then follows SPAWN_HELD rather than staying up unconditionally.
+    ## Set from the global_flags watch the moment a load begins (LOADING_LEVEL /
+    ## LOAD_SCREEN added), or via boot_deadline as a backstop; the splash then
+    ## follows SPAWN_HELD rather than staying up unconditionally.
   boot_deadline: MonoTime
     ## Hand the splash to the gate no later than this, so it can never stick on
     ## a client that never runs a local load.
@@ -307,10 +308,12 @@ gdobj Game of Node:
     # render off while the player is held at the spawn, revealed the frame
     # the gate releases.
     if not self.load_screen.is_nil:
-      if not self.gate.booted and (
-        LOADING_LEVEL in state.global_flags or
-        LOAD_SCREEN in state.global_flags or time > self.gate.boot_deadline
-      ):
+      # `booted` is set from the global_flags watch the moment a load begins
+      # (LOADING_LEVEL/LOAD_SCREEN added). That's edge-triggered and ordered, so
+      # a fast load — added and removed before this thread next runs — still
+      # flips it; a per-frame `x in state.global_flags` membership test here used
+      # to miss exactly that, leaving the splash up until the deadline below.
+      if not self.gate.booted and time > self.gate.boot_deadline:
         self.gate.booted = true
       let show =
         if self.gate.booted: SPAWN_HELD in state.local_flags else: true
@@ -747,6 +750,11 @@ gdobj Game of Node:
         self.set_font_size(state.config.font_size)
 
     state.global_flags.changes:
+      if LOADING_LEVEL.added or LOAD_SCREEN.added:
+        # A load has begun — the boot splash hands off to the spawn gate. Edge-
+        # triggered (not a per-frame membership test) so a fast load whose flags
+        # are added and removed between this thread's frames still flips it.
+        self.gate.booted = true
       if LOAD_SCREEN.added:
         # Splash phase: hold this machine's player frozen at the spawn while
         # the units ahead of the PLAYERS load_order step load and run.


### PR DESCRIPTION
An ungated level (PLAYERS first, e.g. `tutorial-1`) is supposed to reveal within a tick — no gate, no splash held. But on a fast **release**-build boot it sat behind the splash for ~8 seconds, right through the welcome bot's "Hi!"/"Welcome to Enu!" dialog.

## Cause
`gate.booted` — which hands the boot splash over to the spawn gate — was computed each frame from a **membership test**: `LOADING_LEVEL in state.global_flags`. A fast load raises and clears `LOADING_LEVEL` between the main thread's frames, so that per-frame test never observed it true, and `booted` only flipped via the 8s `boot_deadline` backstop. A slow gated level (`welcome`) holds `LOAD_SCREEN` up for seconds, so its membership test *was* caught — which is exactly why gating worked and the ungated fast path didn't.

## Fix
Flip `booted` from the `state.global_flags.changes` **watch** on `LOADING_LEVEL`/`LOAD_SCREEN` *added*, instead of the per-frame membership test. ed delivers changes in order, so the `added` edge is seen even when a `removed` follows in the same batch — the same mechanism that already makes the `LOAD_SCREEN` gate reliable. The per-frame path keeps only the `boot_deadline` backstop. One-file change in `game.nim`.

## Verification (release build, `--temp-workdir`)
- `tutorial-1` (PLAYERS first): `booted` now flips via the watch (`by_loading=true`) the moment the node is up, not the 8s deadline — splash gone before the bot dialog.
- `welcome` (PLAYERS at 9, gated): unchanged — booted flips via `LOAD_SCREEN`, and the gate still holds ("waiting for local render" on its 8-unit pre-reveal set) until they render.
- `nim build` + `nim test` pass.

Supersedes #97 (the earlier flush attempt) and #99 (the blunt full-disable stopgap) — both can be closed.