### PR TITLE
Fix toolbar squish at small sizes and lean-erasing scale writes

### DIFF
--- a/src/controllers/script_controllers/host_bridge.nim
+++ b/src/controllers/script_controllers/host_bridge.nim
@@ -711,10 +711,11 @@ proc `scale=`(self: Thing, scale: float) =
   # so previously scale only reached the basis asynchronously, via a
   # node→model writeback in build_node/bot_node that raced with — and
   # clobbered — a concurrent `rotation=`. Doing it here removes the race.
-  let degrees = self.rotation
-  let pivot_basis = Transform.init.basis
-    .rotated(UP, deg_to_rad(degrees))
-    .scaled(vec3(scale, scale, scale))
+  # Keep the full current orientation (orthonormalized to strip the old
+  # scale) rather than rebuilding from yaw — reconstructing from
+  # `self.rotation` alone was erasing any pitch/roll set by `lean`.
+  let pivot_basis =
+    self.pivot_basis.orthonormalized.scaled(vec3(scale, scale, scale))
   self.set_pivot_basis(pivot_basis)
 
 proc sees(

--- a/src/ui/toolbar.nim
+++ b/src/ui/toolbar.nim
@@ -73,29 +73,27 @@ gdobj Toolbar of HBoxContainer:
     # Slide the toolbar down and back up, swapping in the updated tool set at the
     # bottom — matching the Settings slide-up look (vertical only).
     #
-    # Derive the resting top-y from the anchored layout every time instead of
-    # caching one read: the toolbar is bottom-anchored with a 5px bottom margin
-    # (GUI.tscn), so its top rests at parent_height - 5 - its own height. Caching
-    # a single early rect_position.y (before the window settled at final size)
-    # was leaving it stranded up-screen after a tools change.
-    let parent = self.get_parent() as Control
-    let rest = parent.rect_size.y - 5.0 - self.rect_size.y
+    # Animate margin_bottom, never rect_position: writing the position of an
+    # anchored control rewrites both margins to pin its current rect, freezing
+    # the container at that height — after which a smaller toolbar_size can only
+    # shrink the buttons' width. Moving the bottom margin keeps the height
+    # anchor-driven, and the rest state is just the scene's 5px bottom margin.
     if ?self.tween:
       self.tween.kill
-    self.rect_position = vec2(self.rect_position.x, rest)
+    self.margin_bottom = -5.0
 
     let drop = self.rect_size.y + 10.0
     self.tween = self.get_tree.create_tween()
     discard self.tween
       .tween_property(
-        self, "rect_position:y", (rest + drop).to_variant, animation_duration
+        self, "margin_bottom", (drop - 5.0).to_variant, animation_duration
       )
       .set_trans(TRANS_EXPO)
       .set_ease(EASE_IN_OUT)
     discard self.tween.tween_callback(self, "_apply_tools")
     discard self.tween
       .tween_property(
-        self, "rect_position:y", rest.to_variant, animation_duration
+        self, "margin_bottom", (-5.0).to_variant, animation_duration
       )
       .set_trans(TRANS_EXPO)
       .set_ease(EASE_IN_OUT)


### PR DESCRIPTION
Two unrelated one-file fixes for regressions from recent UI/scripting work.

## Toolbar buttons stretched into tall rectangles below ~90

`animate_tools` slid the toolbar by writing `rect_position`, which rewrites both margins to pin the control's current rect — permanently freezing the bottom-anchored container's height at whatever it was when the first tools change fired. From then on a smaller `toolbar_size` only narrowed the buttons' min width, and the HBoxContainer stretched them vertically to fill the frozen height.

The slide now tweens `margin_bottom`, so the height stays anchor-driven (always the buttons' minimum size) and the rest state is just the scene's 5px bottom margin. This also replaces the derived rest-y workaround from 2f09f841 — position writes are gone entirely, so there's nothing to re-derive.

## `lean` undone by `scale =`

The synchronous scale composition from 2838ba18 rebuilt the pivot basis from `self.rotation` (yaw only) + scale, erasing any pitch/roll on the next scale write. The tutorial-2 bell — `lean 179` followed by a `forever` loop pulsing `scale` — snapped upright on the loop's first iteration. `scale=` now orthonormalizes the current pivot basis (stripping the old scale) and rescales it, preserving the full orientation.

Verified in-game: toolbar buttons stay square through tool-set slides at `toolbar_size` 40, and the bell hangs upside down while spinning/pulsing. `nim test` passes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)