### PR TITLE
fix: stale bulk-adopted snapshot overwrote freshly drawn voxels

### DIFF
--- a/src/models/builds.nim
+++ b/src/models/builds.nim
@@ -217,17 +217,40 @@ proc maybe_join_previous_build(
             current_build = dest
             return
 
+proc empty_bounds*(): AABB {.inline.} =
+  ## The "no chunks yet" sentinel. Its size is negative, so it can't be fed
+  ## to merge/expand — every grower has to seed from it explicitly.
+  init_aabb(vec3(), vec3(-1, -1, -1))
+
 proc expand_bounds_to_chunk*(self: Build, chunk_id: Vector3) =
+  ## Grow the bounds to cover `chunk_id`. The terrain clips loading and
+  ## meshing to these bounds, so every chunk the store holds has to end up
+  ## inside them — this is unconditional and idempotent, and there is no
+  ## path that can skip it.
+  ##
+  ## It deliberately does not test containment first: AABB.contains in
+  ## godot-nim compares point.z against position.x, so the guard it used to
+  ## have dropped legitimate expansions and left units clipped.
+  ## `expand` rather than `merge`: merge is a GDNative call, so it is
+  ## unavailable to unit tests (and an FFI hop per chunk); expand is pure Nim.
   let range = chunk_id * ChunkSize
-  let min = range - ChunkSize - vec3(1, 1, 1)
-  let max = range + ChunkSize
-  if max notin self.bounds:
-    self.bounds = self.bounds.expand(max)
-  if min notin self.bounds:
-    self.bounds = self.bounds.expand(min)
+  let low = range - ChunkSize - vec3(1, 1, 1)
+  let high = range + ChunkSize
+  self.bounds =
+    if self.bounds == empty_bounds():
+      init_aabb(low, high - low)
+    else:
+      self.bounds.expand(low).expand(high)
+
+proc track_chunk_bounds*(self: Build) =
+  ## Every store this build owns reports its chunks here, so bounds growth
+  ## has one definition rather than one per construction path.
+  let build = self
+  self.voxels.on_chunk_created = proc(chunk_id: Vector3) =
+    build.expand_bounds_to_chunk(chunk_id)
 
 proc reset_bounds*(self: Build) =
-  self.bounds = init_aabb(vec3(), vec3(-1, -1, -1))
+  self.bounds = empty_bounds()
 
   for chunk_id in self.voxels.chunk_ids:
     self.expand_bounds_to_chunk(chunk_id)
@@ -778,7 +801,7 @@ proc init*(
         EdValue[Transform].init(Transform.init, flags = {SYNC_LOCAL, SYNC_REMOTE}),
       start_color: color,
       drawing: true,
-      bounds_value: ed(init_aabb(vec3(), vec3(-1, -1, -1))),
+      bounds_value: ed(empty_bounds()),
       clone_of: clone_of,
       bot_collisions: bot_collisions,
       parent: parent,
@@ -792,10 +815,7 @@ proc init*(
     self.voxels.edit_deltas = self.shared.edit_deltas
     self.voxels.rebuild_local_edits()
 
-    # Expand bounds as chunks are created (for early chunk loading)
-    let build = self
-    self.voxels.on_chunk_created = proc(chunk_id: Vector3) =
-      build.expand_bounds_to_chunk(chunk_id)
+    self.track_chunk_bounds()
 
     if global:
       self.global_flags += GLOBAL
@@ -881,10 +901,7 @@ proc init_voxels_if_needed*(self: Build, rebuild_edits = true) =
     )
     if rebuild_edits:
       self.voxels.rebuild_local_edits()
-    # Expand bounds as chunks are created
-    let build = self
-    self.voxels.on_chunk_created = proc(chunk_id: Vector3) =
-      build.expand_bounds_to_chunk(chunk_id)
+    self.track_chunk_bounds()
 
 proc setup_packed_chunk_watches(self: Build) =
   ## Set up watches for packed_chunks and chunk_deltas to reconstruct local voxels on clients.

--- a/src/models/voxels/store.nim
+++ b/src/models/voxels/store.nim
@@ -11,6 +11,17 @@ import ./codec
 proc shared_of(self: VoxelStore): Shared =
   if ?self.build: self.build.shared_value.value else: nil
 
+proc note_chunk*(self: VoxelStore, chunk_id: Vector3) {.inline.} =
+  ## This store now holds `chunk_id`. The owner grows the unit's bounds from
+  ## it — the terrain clips loading and meshing to those bounds, so a chunk
+  ## that never reports here is a chunk that never renders.
+  ##
+  ## Call it from anywhere a chunk enters the store, unconditionally: it is
+  ## idempotent, and a condition on one caller and not another is exactly how
+  ## chunks went missing before.
+  if not self.on_chunk_created.is_nil:
+    self.on_chunk_created(chunk_id)
+
 proc init*(
     _: type VoxelStore,
     ctx: EdContext = nil,
@@ -229,6 +240,30 @@ iterator flush_dirty_chunks*(self: VoxelStore): Vector3 =
   ## remaining chunks to coalesce and flush on a later frame, so a single large
   ## (ASAP) draw burst can't overshoot the channel in one go. Drain it fully (the
   ## `proc` overload below) to flush everything, e.g. for save / end_asap.
+  # Bulk-adopted snapshots first. A staged blob is the chunk's state as of
+  # adoption, so it belongs underneath anything drawn since — draining it
+  # after the pending draws republished a stale blob over fresher content and
+  # cleared their deltas, losing the drawing outright.
+  for chunk_id in self.pending_snapshots.keys.to_seq:
+    let blob = self.pending_snapshots[chunk_id]
+    # A snapshot supersedes a chunk's deltas and pending changes only when it
+    # was encoded from that chunk's current cells. The staged blob wasn't, so
+    # it's authoritative only while the chunk is untouched since adoption.
+    # Once something has drawn into it, re-encode from the cells — those
+    # already fold packed (+) deltas (+) pending — and let that supersede.
+    # (Ordering alone wouldn't do: the worker breaks out of this iterator on
+    # channel pressure, so a staged blob can outlive a pass in which draws
+    # flushed.)
+    if blob.data.len == 0 or chunk_id in self.pending_chunks:
+      self.flush_chunk_snapshot(chunk_id)
+      self.pending_chunks.del chunk_id
+    else:
+      self.packed_chunks[chunk_id] = blob # bulk-adopted, publish verbatim
+      if chunk_id in self.chunk_deltas:
+        self.chunk_deltas[chunk_id].clear
+      inc self.snapshots_flushed
+    self.pending_snapshots.del chunk_id
+    yield chunk_id
   for chunk_id in self.pending_chunks.keys.to_seq:
     let changes = self.pending_chunks[chunk_id]
     let has_snapshot = chunk_id in self.packed_chunks
@@ -244,17 +279,6 @@ iterator flush_dirty_chunks*(self: VoxelStore): Vector3 =
     else:
       self.flush_chunk_delta(chunk_id, changes)
     self.pending_chunks.del chunk_id
-    yield chunk_id
-  for chunk_id in self.pending_snapshots.keys.to_seq:
-    let blob = self.pending_snapshots[chunk_id]
-    if blob.data.len > 0:
-      self.packed_chunks[chunk_id] = blob # bulk-adopted, publish verbatim
-      if chunk_id in self.chunk_deltas:
-        self.chunk_deltas[chunk_id].clear
-      inc self.snapshots_flushed
-    else:
-      self.flush_chunk_snapshot(chunk_id)
-    self.pending_snapshots.del chunk_id
     yield chunk_id
 
 proc flush_dirty_chunks*(self: VoxelStore) =
@@ -352,10 +376,12 @@ proc adopt_chunk(
       continue
     chunk.cells[linear] = v
     inc chunk.count
+  # Bounds first, and for every adopted chunk: an all-HOLE chunk installs
+  # nothing but still occupies space the terrain has to be allowed to load,
+  # and `chunk_ids` counts it, so reset_bounds would cover it anyway.
+  self.note_chunk(chunk_id)
   if chunk.count == 0:
     return
-  if not self.on_chunk_created.is_nil:
-    self.on_chunk_created(chunk_id)
   inc self.cache_tick
   chunk.tick = self.cache_tick
   self.chunk_cache[chunk_id] = chunk
@@ -451,8 +477,7 @@ proc add_voxel*(self: VoxelStore, position: Vector3, voxel: VoxelInfo) =
   let chunk = self.cached_chunk(chunk_id)
   let linear = linear_position(position)
 
-  if chunk.count == 0 and not self.on_chunk_created.is_nil:
-    self.on_chunk_created(chunk_id)
+  self.note_chunk(chunk_id)
 
   let packed =
     pack_voxel(pack_color_index(self.shared_of, voxel.color), voxel.kind.ord)
@@ -636,6 +661,7 @@ proc apply_snapshot*(
   ## decode installs directly: the cache is the store.
   if snapshot.data.len == 0:
     return
+  self.note_chunk(chunk_id)
   if ?self.build:
     self.chunk_cache.del(chunk_id)
   else:
@@ -649,6 +675,16 @@ proc unload_chunk*(self: VoxelStore, chunk_id: Vector3) =
   ## Drop a paged-out chunk's local state (the voxel paging counterpart of
   ## apply_snapshot). The data still exists on the authority; a later
   ## `request` re-applies it.
+  ##
+  ## "The authority has it" holds for flushed content only. Unflushed writes
+  ## in `pending_chunks` have not reached the synced tables, so dropping them
+  ## here loses them outright — the same hazard `cached_chunk`'s eviction
+  ## invariant refuses to take.
+  if chunk_id in self.pending_chunks:
+    warn "page-out dropping unflushed voxel writes",
+      unit = self.thing_id,
+      chunk = $chunk_id,
+      writes = self.pending_chunks[chunk_id].len
   self.chunk_cache.del(chunk_id)
   self.pending_chunks.del(chunk_id)
 

--- a/tasks.nim
+++ b/tasks.nim
@@ -176,6 +176,7 @@ task test_unit, "run unit tests":
   exec "nim c -r tests/unit/tool_availability_test"
   exec "nim c -r tests/unit/path_safety_test"
   exec "nim c -r tests/unit/stroke_paint_test"
+  exec "nim c -r tests/unit/bounds_test"
 
 task test_vm, "run VM script tests":
   exec "nim c -r tests/vm/runner"

--- a/tests/unit/bounds_test.nim
+++ b/tests/unit/bounds_test.nim
@@ -1,0 +1,102 @@
+import unittest2
+import core
+import models/colors
+import models/builds
+
+# The terrain clips chunk loading and meshing to a unit's bounds, so a chunk
+# that lands outside them never renders. These cover the two ways that broke:
+# an expansion that got skipped, and the negative-coordinate case that skipped
+# it (godot-nim's AABB.contains compares point.z against position.x, so the
+# containment guard this used to have reported false positives on -z).
+
+proc test_build(): Build =
+  Build.init(id = "bounds_test", transform = Transform.init, color = ACTION_COLORS[BLACK])
+
+proc covers(self: Build, chunk_id: Vector3): bool =
+  ## Every corner of the chunk has to be inside the bounds, not just its origin.
+  let low = chunk_id * ChunkSize
+  for dx in [0.0, ChunkDim.float]:
+    for dy in [0.0, ChunkDim.float]:
+      for dz in [0.0, ChunkDim.float]:
+        let corner = low + vec3(dx, dy, dz)
+        let b = self.bounds
+        if corner.x < b.position.x or corner.x > b.position.x + b.size.x or
+            corner.y < b.position.y or corner.y > b.position.y + b.size.y or
+            corner.z < b.position.z or corner.z > b.position.z + b.size.z:
+          return false
+  true
+
+suite "Build bounds":
+  test "a single chunk at the origin is covered":
+    let build = test_build()
+    build.reset_bounds()
+    build.expand_bounds_to_chunk(vec3(0, 0, 0))
+    check build.covers(vec3(0, 0, 0))
+
+  test "negative chunk coordinates are covered on every axis":
+    for chunk_id in [
+      vec3(-1, 0, -1), vec3(-2, 0, -2), vec3(0, 0, -2), vec3(-4, 0, 9),
+      vec3(-6, 0, -3), vec3(8, 0, -2),
+    ]:
+      let build = test_build()
+      build.reset_bounds()
+      build.expand_bounds_to_chunk(chunk_id)
+      check build.covers(chunk_id)
+
+  test "expanding never drops an earlier chunk":
+    # The regression: growing toward +z used to leave a -z chunk outside.
+    let build = test_build()
+    build.reset_bounds()
+    let chunks =
+      [vec3(1, 0, -2), vec3(2, 0, -2), vec3(6, 0, -2), vec3(0, 0, 0), vec3(8, 0, 9)]
+    for chunk_id in chunks:
+      build.expand_bounds_to_chunk(chunk_id)
+    for chunk_id in chunks:
+      check build.covers(chunk_id)
+
+  test "a -z chunk is covered when the bounds already reach further in -x":
+    # The real regression. The old guard asked `low notin bounds` first, and
+    # godot-nim's AABB.contains compares point.z against position.x — so once
+    # the bounds reached further along -x than -z, a chunk at more-negative z
+    # reported as already contained and its expansion was dropped. The unit
+    # then rendered with those chunks clipped away. This is the shape the
+    # tutorial-3 maze had: x down to -83 but z only to -31.
+    let build = test_build()
+    build.reset_bounds()
+    build.expand_bounds_to_chunk(vec3(-8, 0, 0)) # push -x far out
+    check build.bounds.position.x <= -49.0
+    build.expand_bounds_to_chunk(vec3(0, 0, -2)) # now grow -z past it
+    check build.covers(vec3(0, 0, -2))
+
+  test "expansion is idempotent and order independent":
+    let forward = test_build()
+    forward.reset_bounds()
+    let backward = test_build()
+    backward.reset_bounds()
+    let chunks = [vec3(-3, 0, -2), vec3(5, 0, 7), vec3(0, 0, -1)]
+    for chunk_id in chunks:
+      forward.expand_bounds_to_chunk(chunk_id)
+      forward.expand_bounds_to_chunk(chunk_id) # twice: must not drift
+    for i in countdown(chunks.high, 0):
+      backward.expand_bounds_to_chunk(chunks[i])
+    # Compared componentwise: AABB's `==` and `$` are GDNative calls, so
+    # unittest2 stringifying a failed check would segfault under no_godot.
+    check forward.bounds.position.x == backward.bounds.position.x
+    check forward.bounds.position.y == backward.bounds.position.y
+    check forward.bounds.position.z == backward.bounds.position.z
+    check forward.bounds.size.x == backward.bounds.size.x
+    check forward.bounds.size.y == backward.bounds.size.y
+    check forward.bounds.size.z == backward.bounds.size.z
+
+  test "the empty sentinel is negative so it can't be grown from by accident":
+    check empty_bounds().size.x < 0
+    check empty_bounds().size.y < 0
+    check empty_bounds().size.z < 0
+
+  test "reset_bounds rebuilds from the store's chunks":
+    # A fresh build already owns the chunk holding its starting voxel, so
+    # reset_bounds yields one chunk's worth: ChunkSize * 2 + 1 per axis.
+    let build = test_build()
+    build.reset_bounds()
+    check build.bounds.size.x == ChunkDim.float * 2 + 1
+    check build.covers(vec3(0, 0, 0))


### PR DESCRIPTION
Chunks of a build could render with most of their voxels missing. It survived reloads, was invisible to the eye in debug builds, and a script re-run "fixed" it — which is what made it so slippery.

## Root cause

A build's persisted edits are bulk-adopted at load and staged in `pending_snapshots` to pace the sync channel. `flush_dirty_chunks` drained the script's draws **first** and the staged blobs **second**, publishing each blob verbatim over `packed_chunks` and clearing the chunk's deltas:

```nim
self.packed_chunks[chunk_id] = blob   # clobbers the draws
if chunk_id in self.chunk_deltas:
  self.chunk_deltas[chunk_id].clear   # and their deltas
```

So when a chunk's draws and its staged blob landed in the same flush pass, the edits-only blob won. Nothing retried — the chunk published fewer voxels than the store held and stayed that way until the script re-ran.

Evidence from the reproduction (tutorial-3 maze, local chunk `(-2,0,0)`):

| | voxels |
|---|---|
| worker live cells | 326 |
| worker published | **2** |
| worker pending | none |
| main | **2** |

2 is exactly that chunk's persisted-edit count. The three neighbouring chunks in the same region have zero persisted edits and were never affected.

That also explains the symptoms: **release-only** (release draws fast enough for both to be pending together; debug usually drains the snapshot in an earlier pass), **load-order sensitive** (shifts when the script runs relative to the flush cadence), and **fixed by re-running the script** (`pending_snapshots` is only staged at load).

## The rule this restores

> A snapshot supersedes a chunk's deltas and pending changes **iff** it was encoded from that chunk's current cells.

`flush_chunk_snapshot` satisfies that — it encodes the cells, which already fold packed + deltas + pending. A staged blob does not, at publish time.

So: drain staged snapshots first, so an adopted blob sits underneath anything drawn since; publish verbatim only while the chunk is untouched, else re-encode from the cells and drop the superseded pending entry. Ordering alone isn't sufficient — the worker breaks out of the iterator under channel pressure, so a staged blob can outlive a pass in which draws flushed. The fresh-load fast path is unchanged: nothing is dirty then, so every chunk still takes the verbatim route.

## Also: unit bounds

The terrain clips chunk loading and meshing to `Build.bounds`, and bounds could come up short:

- `expand_bounds_to_chunk` guarded on `AABB.contains`, which compares `point.z` against `position.x` in godot-nim (see getenu/godot-nim#1) — expansions were silently dropped once a unit reached further along -x than -z. Now unconditional and idempotent.
- The two `on_chunk_created` fire sites had *opposite* count guards, and a third path never reported at all. All routed through `note_chunk`.
- `unload_chunk` now warns when page-out drops unflushed writes — `cached_chunk`'s eviction explicitly refuses that trade; `unload_chunk` didn't guard it.

## Verification

Deterministic harness: a pristine level fixture restored before every run (Enu rewrites `load_order` on load, which silently changed the input between trials otherwise), release build, cold load, scored as pixel diff against a known-good render.

- Before: **2/2 broken** (1.957%, 1.848% of sampled pixels differing)
- After: **3/3 healthy** (0.109%, 0.109%, 0.000%)

`nim build`, `nim build -d:release`, and `nim test_all` all pass. `tests/unit/bounds_test.nim` is new and registered in `tasks.nim` (unit tests are listed explicitly, not discovered); its `-z`-chunk case fails on the old bounds code and passes on the new.

Level data is deliberately not included in this PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)