### PR TITLE
gate: don't strand the terrain generator; bound the splash's waits

### DIFF
--- a/src/game.nim
+++ b/src/game.nim
@@ -64,11 +64,19 @@ proc get_network_stats(): string =
 const savable_flags =
   {CONSOLE_VISIBLE, MOUSE_CAPTURED, FLYING, GOD, ALT_WALK_SPEED, ALT_FLY_SPEED}
 
-const SPAWN_GATE_TIMEOUT = 30.seconds
+const SPAWN_GATE_TIMEOUT = 10.seconds
   ## Backstop on how long the reveal waits for the pre-PLAYERS builds to
   ## report rendered after LOAD_SCREEN clears. Never the normal path — a
   ## wedged mesh task or a build that can't settle must not hold the splash
-  ## forever.
+  ## forever. Settling is local meshing of already-loaded data: sub-second in
+  ## practice, so anything near this is a bug, and the error names the units
+  ## that were still holding it.
+
+const SPAWN_GATE_WARM_TIMEOUT = 1.second
+  ## Backstop on the warm-up half. It waits for two real draws behind the
+  ## splash, which needs the engine to actually be drawing — a minimized or
+  ## occluded window (every MCP-managed and test instance) stops incrementing
+  ## frames_drawn entirely, and without this the splash never lifts at all.
 
 
 var environment_cache {.threadvar.}: Table[string, Environment]
@@ -102,6 +110,8 @@ type SpawnGate = object
   settle_streak: int
   warm_drawn_at: int64
     ## get_frames_drawn() when warming began; lift at +2.
+  warm_deadline: MonoTime
+    ## Lift by this time even if the frame counter never advances.
   deadline: MonoTime
   started: MonoTime
 
@@ -144,7 +154,7 @@ gdobj Game of Node:
     if self.gate.active:
       let time = get_mono_time()
       if not self.gate.warming:
-        var ready = true
+        var blocking: seq[string]
         state.things.value.walk_tree proc(thing: Thing) =
           if thing of Build and thing.id in self.gate.ids and
               thing.pending_block_updates != 0:
@@ -154,18 +164,29 @@ gdobj Game of Node:
             let b = Build(thing)
             if b.packed_chunks.len > 0 or b.chunk_deltas.len > 0 or
                 b.frames.len > 0:
-              ready = false
-        if ready:
+              blocking.add thing.id & "=" & $thing.pending_block_updates
+        if blocking.len == 0:
           inc self.gate.settle_streak
         else:
           self.gate.settle_streak = 0
         if self.gate.settle_streak >= 2 or time > self.gate.deadline:
           if self.gate.settle_streak < 2:
+            # Name the units and their counts: settling is local meshing of
+            # data that's already in memory, so a unit still pending here has
+            # something wrong with it specifically, not with the level.
             error "spawn gate: deadline exceeded; revealing anyway",
-              gate_ids = self.gate.ids
+              blocking = blocking, gate_ids = self.gate.ids
           self.gate.warming = true # the splash block enables the viewport
           self.gate.warm_drawn_at = get_frames_drawn()
-      elif get_frames_drawn() >= self.gate.warm_drawn_at + 2:
+          self.gate.warm_deadline = time + SPAWN_GATE_WARM_TIMEOUT
+      elif get_frames_drawn() >= self.gate.warm_drawn_at + 2 or
+          time > self.gate.warm_deadline:
+        if get_frames_drawn() < self.gate.warm_drawn_at + 2:
+          # Nothing was drawn during the warm-up: the window can't draw
+          # (minimized/occluded), so waiting on the frame counter would hold
+          # the splash forever. Lift it — there's nothing to warm.
+          notice "spawn gate: no draws during warm-up; revealing anyway",
+            drawn = get_frames_drawn()
         info "spawn gate: released",
           waited_ms = (time - self.gate.started).in_milliseconds
         self.gate.active = false

--- a/src/nodes/build_node.nim
+++ b/src/nodes/build_node.nim
@@ -61,6 +61,12 @@ gdobj BuildNode of VoxelTerrain:
     toggle_error_highlight_at = MonoTime.high
     error_highlight_on: bool
     next_stats_log: MonoTime
+    stream_floor_until: MonoTime
+    stream_floor_expired: bool
+    generating = true
+      ## Whether the terrain currently has its generator. Mirrors "RESETTING
+      ## notin the model's flags" — see keep_generator_in_sync. Starts true:
+      ## the scene ships a VoxelGeneratorFlat.
     prefill_hits, prefill_misses: int
     prefill_gated, prefill_miss_with_data: int
       ## Perf-log breakdown of misses: requests refused before the store was
@@ -486,10 +492,9 @@ gdobj BuildNode of VoxelTerrain:
         # a rerun always starts from live display, whatever was showing
         self.frames.reset()
         self.loaded_chunks.clear()
-        self.generator = nil
-        self.stream = nil
+        self.keep_generator_in_sync()
       elif RESETTING.removed:
-        self.generator = gdnew[VoxelGeneratorFlat]()
+        self.keep_generator_in_sync()
       elif HIGHLIGHT_ERROR.added:
         self.toggle_error_highlight_at = get_mono_time() + error_flash_time
         self.error_highlight_on = true
@@ -588,6 +593,7 @@ gdobj BuildNode of VoxelTerrain:
 
   method process(delta: float) =
     if ?self.model:
+      self.keep_generator_in_sync()
       # Sync node->model only when the script isn't driving us this frame. While a
       # model->node update is pending (applied next physics_process), the node is
       # a frame stale, so writing it back would fight the script and bounce. With
@@ -641,7 +647,19 @@ gdobj BuildNode of VoxelTerrain:
           # been computed for a viewer — "not started" would be published
           # as "done", and loading-completion checks (the spawn gate,
           # wait_for_script) would release early.
-          pending = max(pending, 1)
+          #
+          # Bounded, because "not started" is only temporary while a viewer
+          # is on its way: a terrain no viewer ever demands (out of range,
+          # unreachable bounds, a viewer that never pairs) has nothing
+          # coming, and an unbounded floor there is a wedge — a build that
+          # published 1 and then went quiet held the whole spawn gate to its
+          # timeout, splash up, with the level fully loaded behind it.
+          if get_mono_time() < self.stream_floor_until:
+            pending = max(pending, 1)
+          elif not self.stream_floor_expired:
+            self.stream_floor_expired = true
+            notice "stream never started; dropping the loading floor",
+              unit = self.model.id, generating = self.generating
         if ?self.frames and SPAWN_HELD in state.local_flags and
             self.frames.display_pending:
           # A frame display in flight (bakes bypass the terrain pipeline, so
@@ -652,6 +670,30 @@ gdobj BuildNode of VoxelTerrain:
           pending.inc
         if pending != self.model.pending_block_updates:
           self.model.pending_block_updates = pending
+
+  proc keep_generator_in_sync() =
+    ## Hold the generator only while the build isn't resetting, derived from
+    ## the flag rather than driven by its edges. A reset adds and removes
+    ## RESETTING inside one worker tick, and the node is created in the middle
+    ## of that window (the script runs right after its thing joins
+    ## state.things): it can see the `added` — as the watch's replay of a flag
+    ## that's already set — while the `removed` that preceded its
+    ## registration never arrives as an edge. The terrain is then left with no
+    ## generator and no stream at all, which turns off streaming wholesale in
+    ## VoxelTerrain::_process: nothing is ever requested, has_stream_started()
+    ## stays false, and the unit publishes the not-started floor forever
+    ## without a single block of work to show for it. That's what held the
+    ## spawn gate to its timeout on a level switch, splash up, over a level
+    ## that had finished loading.
+    let generating = RESETTING notin self.model.global_flags
+    if generating == self.generating:
+      return
+    self.generating = generating
+    if generating:
+      self.generator = gdnew[VoxelGeneratorFlat]()
+    else:
+      self.generator = nil
+      self.stream = nil
 
   proc publishes_pending(): bool =
     ## Whether this machine's node is the authority for the build's synced
@@ -702,6 +744,10 @@ gdobj BuildNode of VoxelTerrain:
     # Palette + slots are live; prefill may now serve resolvable chunks.
     self.palette_published = true
 
+    # How long "hasn't started streaming" counts as still loading. Pairing a
+    # viewer and computing its required set takes a frame or two; measured at
+    # well under a second even for the biggest terrains in a debug build.
+    self.stream_floor_until = get_mono_time() + init_duration(seconds = 3)
     if self.model.code.owner == state.worker_ctx_name or self.publishes_pending:
       # Publish the not-yet-started floor immediately: the model initializes
       # pending_block_updates to 0, and a loading-completion check can run


### PR DESCRIPTION
Loading a level from inside another one (clicking a sign link that evals `load_level("welcome")`) held the splash for the full 30s spawn-gate timeout, then revealed with `spawn gate: deadline exceeded`. The level had finished loading well before that — the process was completely idle for the whole wait (`snapshots_delta=0`, no meshing), with `build_water` the only unit still reporting pending work.

## Root cause

`build_node` drops the terrain's generator and stream on `RESETTING.added` and restores them on `RESETTING.removed`. But `Build.reset()` adds *and* removes `RESETTING` inside one worker tick, and a build's node is created in the middle of that window — its script runs right after the thing joins `state.things`. The node can see the `added`, as its watch replaying a flag that is already set, while the `removed` that preceded its registration never arrives as an edge.

The terrain is then left with no generator and no stream at all, which turns streaming off wholesale in `VoxelTerrain::_process` (`stream_enabled` false): no blocks are ever requested, `has_stream_started()` never becomes true, and the unit publishes the not-started floor of 1 forever with no work behind it. The spawn gate waits on that until it times out.

`keep_generator_in_sync` now derives the generator from the flag each frame instead of trusting its edges.

**Evidence:** booting `tutorial-3` stranded three units deterministically — `build_3npxfmddql9kx`, `build_mlsxf11t2oaz6`, `build_wevpat48mxjhe` each logged "stream never started" on both pre-fix runs. After the fix, none, across every run since.

## Bounding the gate

So no single unit can hold the splash again:

- **The not-started floor expires after 3s.** It exists to stop a terrain reading "done" before its required set is computed — a frame or two, measured well under a second even for the 6528-chunk terrain. Past that nothing is coming, and it logs the unit it dropped plus whether it still had a generator.
- **The warm-up lifts after 1s** even if `get_frames_drawn()` never advances. It waits for two real draws behind the splash, which needs the engine to actually be drawing; a minimized or occluded window (every MCP-managed and test instance) freezes that counter, and the splash never lifted at all, with nothing logged. This was a second, independent way to hang the splash forever.
- **Settle timeout 30s → 10s**, and the deadline error names the blocking units with their counts (`blocking=["build_water=1"]`) instead of just the whole gate set.

## Testing

`nim test_all` passes. Switch timings for tutorial-3 → welcome: 628ms with a drawing window, 1.58s minimized (previously: 30s timeout, or never).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
