### PR TITLE
macos: File > Open... and a welcome item in the Help menu

### DIFF
--- a/app/project.godot
+++ b/app/project.godot
@@ -303,6 +303,15 @@ settings={
 "deadzone": 0.5,
 "events": [  ]
 }
+open_world={
+"deadzone": 0.5,
+"events": [  ]
+}
+open_world.macosx={
+"deadzone": 0.5,
+"events": [ Object(InputEventKey,"resource_local_to_scene":false,"resource_name":"","device":0,"alt":false,"shift":false,"control":false,"meta":true,"command":true,"pressed":false,"scancode":79,"physical_scancode":0,"unicode":0,"raw_code":0,"echo":false,"script":null)
+ ]
+}
 
 [layer_names]
 

--- a/src/game.nim
+++ b/src/game.nim
@@ -1,5 +1,5 @@
 import std/[monotimes, os, json, math, random, net, strformat]
-import pkg/[godot, metrics]
+import pkg/[godot, metrics, osdialog]
 when defined(metrics):
   import metrics_server
 from dotenv import nil
@@ -474,6 +474,11 @@ gdobj Game of Node:
       connect_address_override = saved_state.connect_address
 
     if host_os == "macosx" and not saved_state.restarting:
+      # File first, so the bar reads Enu | File | Help. A client joined to
+      # someone else's world can't open one of its own, so it gets neither the
+      # File menu nor the welcome item (same test as below).
+      if connect_address_override == "":
+        global_menu_add_item("File", "Open...", "open".to_variant, "".to_variant)
       global_menu_add_item(
         "Help", "Documentation", "help".to_variant, "".to_variant
       )
@@ -481,7 +486,7 @@ gdobj Game of Node:
       if connect_address_override == "":
         global_menu_add_separator("Help")
         global_menu_add_item(
-          "Help", "Launch Tutorial", "tutorial".to_variant, "".to_variant
+          "Help", "Enu Welcome", "welcome".to_variant, "".to_variant
         )
 
     when host_os == "ios":
@@ -887,14 +892,27 @@ gdobj Game of Node:
       state.push_flag SETTINGS_VISIBLE
     elif action == "openurl":
       logger("info", \"Open URL: {id}")
-    elif action == "tutorial":
+    elif action == "open":
+      self.open_world()
+    elif action == "welcome":
       state.config_value.value:
         level_dir = ""
       state.player.transform = Transform.init(origin = vec3(0, 2, 0))
       state.player.rotation = 0
-      change_loaded_level("tutorial-1", "tutorial")
+      change_loaded_level("welcome", "tutorial")
     else:
       warn "Unknown action", action, id
+
+  proc open_world() =
+    ## File > Open... (macOS only, from the menu or ⌘O). The same native
+    ## directory picker as Settings > Level > Open..., and the same rules for
+    ## what a picked directory means. The dialog is modal on the main thread, so
+    ## release the pointer first — otherwise the mouse stays captured by a game
+    ## the player can't see behind the dialog.
+    state.pop_flag MOUSE_CAPTURED
+    let picked = file_dialog(fdOpenDir, path = state.config.world_dir)
+    if ?picked:
+      open_picked_dir(picked)
 
   proc switch_world(diff: int) =
     var config = state.config
@@ -947,6 +965,11 @@ gdobj Game of Node:
     ):
       state.config_value.value:
         full_screen = not state.config.full_screen
+    elif event.is_action_pressed("open_world"):
+      # Bound on macOS only (⌘O); the base action ships with no events, so this
+      # never fires elsewhere.
+      self.open_world()
+      self.get_tree().set_input_as_handled()
     elif event.is_action_pressed("settings"):
       state.set_flag SETTINGS_VISIBLE, SETTINGS_VISIBLE notin state.local_flags
     elif event.is_action_pressed("next_level"):

--- a/src/models/serializers.nim
+++ b/src/models/serializers.nim
@@ -1024,6 +1024,23 @@ proc change_loaded_level*(level, world: string) =
   config.level_dir = join_path(world_dir, level)
   state.config = config
 
+proc open_picked_dir*(picked: string) =
+  ## Load whatever the user picked in an Open dialog. Any directory can be a
+  ## world. If the pick is actually an Enu *level* (it has a level.json), open
+  ## its parent world at that level; otherwise treat the dir as a world and open
+  ## its initial level — creating world.json and a "default" level on load when
+  ## it has neither.
+  var world_dir, level: string
+  if file_exists(picked / "level.json"):
+    world_dir = picked.parent_dir
+    level = picked.last_path_part
+  else:
+    world_dir = picked
+    let init =
+      read_world_initial_level(picked, state.config.lib_dir, picked.last_path_part)
+    level = if ?init: init else: "default"
+  change_loaded_level(level, world_dir)
+
 proc run_state_initializers*(worker: Worker) =
   # Re-establish VM-side globals (players.nim's `player`, etc.) registered via
   # register_state_init. Must run after every interpreter rebuild before any

--- a/src/ui/settings.nim
+++ b/src/ui/settings.nim
@@ -425,20 +425,7 @@ gdobj Settings of PanelContainer:
       self.update_values()
       return
 
-    # Any directory can be a world. If the pick is actually an Enu *level* (it
-    # has a level.json), open its parent world at that level; otherwise treat the
-    # dir as a world and open its initial level — creating world.json and a
-    # "default" level on load when it has neither.
-    var world_dir, level: string
-    if file_exists(picked / "level.json"):
-      world_dir = picked.parent_dir
-      level = picked.last_path_part
-    else:
-      world_dir = picked
-      let init =
-        read_world_initial_level(picked, state.config.lib_dir, picked.last_path_part)
-      level = if ?init: init else: "default"
-    change_loaded_level(level, world_dir)
+    open_picked_dir(picked)
     state.pop_flag SETTINGS_VISIBLE
 
   method on_button_up*(name: string) =


### PR DESCRIPTION
Two macOS menu-bar changes.

**Help > Enu Welcome** — was "Launch Tutorial" opening `tutorial-1`; it opens the welcome level now, which is where a new player should start.

**File > Open...** — a new File menu, before Help, running the same native directory picker as Settings > Level > Open... and following the same rules for what a picked directory means (a dir with a `level.json` is a level: open its parent world at that level; anything else is a world, opened at its initial level). That resolution moved out of `Settings.show_open_world` into `open_picked_dir` so both entry points share one implementation.

⌘O works as you'd expect from a File menu. Godot 3.5's global menu API builds every item with `keyEquivalent:@""` and has no way to attach one, so the shortcut is a normal input action instead: `open_world` ships with no events and only `open_world.macosx` binds ⌘O, so `is_action_pressed` stays valid on every platform but can only fire here. Being modal on the main thread, the picker releases the pointer first — otherwise the mouse stays captured by a game the player can't see behind the dialog.

Both are gated on `connect_address_override == ""`, the same test the welcome item already used: a client joined to someone else's world can't open one of its own.

## Testing

`nim test` passes. Driven against a running Enu on macOS:

- Menu bar reads `Apple, Enu, File, Help`; File contains `Open...`, Help contains `Documentation, Web Site, ---, Enu Welcome`.
- ⌘O (via the action) and clicking File > Open... each open the native dialog.
- Escape cancels with no level change; picking `…/tutorial/welcome` loads that level.

🤖 Generated with [Claude Code](https://claude.com/claude-code)